### PR TITLE
feat: add plugins for local externals, GObject decorators, and formating to enhance build process

### DIFF
--- a/build/formatting.ts
+++ b/build/formatting.ts
@@ -1,0 +1,77 @@
+// JS keywords that should NOT be treated as method declarations
+const JS_KEYWORDS = new Set([
+  'if', 'for', 'while', 'switch', 'return', 'throw', 'try', 'catch',
+  'finally', 'else', 'do', 'new', 'typeof', 'void', 'delete', 'await',
+  'yield', 'debugger', 'with', 'break', 'continue', 'case', 'default',
+  'super', 'this', 'true', 'false', 'null', 'undefined',
+]);
+
+// Add blank lines between class methods, between the last field and first
+// method, and between top-level declarations. esbuild strips these blank
+// lines during compilation and prettier does not re-add them.
+export function addBlankLinesBetweenMembers(code: string): string {
+  const lines = code.split('\n');
+  const result: string[] = [];
+
+  const isMethodDecl = (trimmed: string): boolean => {
+    const m = trimmed.match(
+      /^(?:(?:get |set |static |async )*([a-zA-Z_$#]\w*)\s*\()/,
+    );
+    return m !== null && !JS_KEYWORDS.has(m[1]);
+  };
+
+  const isComment = (trimmed: string): boolean =>
+    trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0 && lines[i].trim() !== '' && lines[i - 1].trim() !== '') {
+      const prev = lines[i - 1];
+      const curr = lines[i];
+      const prevTrimmed = prev.trimStart();
+      const currTrimmed = curr.trimStart();
+      const prevIndent = prev.search(/\S|$/);
+      const currIndent = curr.search(/\S|$/);
+      let needsBlank = false;
+
+      const isClosingBrace = /^\};?$/.test(prevTrimmed);
+
+      // Between methods: closing } at indent N → method decl at indent N
+      if (
+        isClosingBrace &&
+        currIndent === prevIndent &&
+        (isMethodDecl(currTrimmed) || isComment(currTrimmed))
+      ) {
+        needsBlank = true;
+      }
+
+      // Between last field and first method at the same indent level
+      if (
+        !needsBlank &&
+        /;$/.test(prevTrimmed) &&
+        /^[a-zA-Z_$#]\w*/.test(prevTrimmed) &&
+        currIndent === prevIndent &&
+        isMethodDecl(currTrimmed)
+      ) {
+        needsBlank = true;
+      }
+
+      // Between top-level declarations (indent 0) after block closures
+      if (
+        !needsBlank &&
+        currIndent === 0 &&
+        /[})\]];?\s*$/.test(prevTrimmed) &&
+        /^(?:var |let |const |function |class |export )/.test(currTrimmed)
+      ) {
+        needsBlank = true;
+      }
+
+      if (needsBlank) {
+        result.push('');
+      }
+    }
+
+    result.push(lines[i]);
+  }
+
+  return result.join('\n');
+}

--- a/build/plugins/girs-resolver.ts
+++ b/build/plugins/girs-resolver.ts
@@ -1,0 +1,59 @@
+import type { Plugin } from 'esbuild';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Resolve @girs/* imports directly to gi:// and resource:// runtime paths,
+// bypassing node_modules to avoid re-export shims and version query strings
+export function createGirsResolver(rootDir: string): Plugin {
+  return {
+    name: 'girs-resolver',
+    setup(ctx) {
+      // @girs/gjs is a type-only shim; drop it entirely
+      ctx.onResolve({ filter: /^@girs\/gjs$/ }, () => ({
+        path: 'gjs',
+        namespace: 'girs-empty',
+      }));
+      ctx.onLoad({ filter: /.*/, namespace: 'girs-empty' }, () => ({
+        contents: '',
+        loader: 'js',
+      }));
+
+      // @girs/gnome-shell/* → resource:///org/gnome/shell/*.js
+      ctx.onResolve({ filter: /^@girs\/gnome-shell\// }, (args) => {
+        const subpath = args.path.replace('@girs/gnome-shell/', '');
+        const distFile = resolve(
+          rootDir,
+          'node_modules/@girs/gnome-shell/dist',
+          `${subpath}.js`,
+        );
+        // Read the actual resource path from the package when the file exists,
+        // otherwise fall back to the standard resource path pattern
+        if (existsSync(distFile)) {
+          const content = readFileSync(distFile, 'utf8');
+          const match = content.match(/from ['"](.+)['"]/);
+          if (match) return { path: match[1], external: true };
+        }
+        return {
+          path: `resource:///org/gnome/shell/${subpath}.js`,
+          external: true,
+        };
+      });
+
+      // @girs/<name>-<version> → gi://<Namespace> (without ?version=)
+      ctx.onResolve({ filter: /^@girs\// }, (args) => {
+        if (args.path === '@girs/gjs' || args.path.startsWith('@girs/gnome-shell/'))
+          return;
+        const pkgName = args.path.replace('@girs/', '');
+        const mainFile = resolve(
+          rootDir,
+          `node_modules/@girs/${pkgName}/${pkgName}.js`,
+        );
+        if (existsSync(mainFile)) {
+          const content = readFileSync(mainFile, 'utf8');
+          const match = content.match(/from ["'](gi:\/\/[^?"']+)/);
+          if (match) return { path: match[1], external: true };
+        }
+      });
+    },
+  };
+}

--- a/build/plugins/gobject-decorator.ts
+++ b/build/plugins/gobject-decorator.ts
@@ -1,0 +1,111 @@
+import type { Plugin } from 'esbuild';
+import { readFileSync } from 'node:fs';
+
+// Transform @GObject.registerClass decorators into GObject.registerClass() calls.
+// This lets source files use the cleaner decorator syntax while emitting the
+// GObject.registerClass(metadata, class ...) form that GJS requires at runtime.
+export const gobjectDecorator: Plugin = {
+  name: 'gobject-decorator',
+  setup(ctx) {
+    ctx.onLoad({ filter: /\.ts$/ }, (args) => {
+      const source = readFileSync(args.path, 'utf8');
+      if (!source.includes('@GObject.registerClass')) return undefined;
+      return { contents: transformGObjectDecorators(source), loader: 'ts' };
+    });
+  },
+};
+
+function transformGObjectDecorators(source: string): string {
+  const DECORATOR = '@GObject.registerClass';
+  let result = source;
+  let searchFrom = 0;
+
+  while (true) {
+    const decoratorIdx = result.indexOf(DECORATOR, searchFrom);
+    if (decoratorIdx === -1) break;
+
+    const replaceStart = decoratorIdx;
+    let pos = decoratorIdx + DECORATOR.length;
+    while (pos < result.length && /\s/.test(result[pos])) pos++;
+
+    let metadata = '';
+    if (result[pos] === '(') {
+      const closePos = findMatchingClose(result, pos);
+      metadata = result.substring(pos + 1, closePos - 1).trim();
+      pos = closePos;
+      while (pos < result.length && /\s/.test(result[pos])) pos++;
+    }
+
+    let hasExport = false;
+    if (result.substring(pos).startsWith('export')) {
+      hasExport = true;
+      pos += 'export'.length;
+      while (pos < result.length && /\s/.test(result[pos])) pos++;
+    }
+
+    if (!result.substring(pos).startsWith('class ')) {
+      searchFrom = pos;
+      continue;
+    }
+
+    const classStart = pos;
+    const nameMatch = result.substring(pos).match(/^class\s+(\w+)/);
+    if (!nameMatch) { searchFrom = pos; continue; }
+    const className = nameMatch[1];
+
+    while (pos < result.length && result[pos] !== '{') pos++;
+    const classEnd = findMatchingClose(result, pos);
+    const classDecl = result.substring(classStart, classEnd);
+
+    const prefix = hasExport ? 'export ' : '';
+    const replacement = metadata
+      ? `${prefix}const ${className} = GObject.registerClass(${metadata}, ${classDecl});`
+      : `${prefix}const ${className} = GObject.registerClass(${classDecl});`;
+
+    result = result.substring(0, replaceStart) + replacement + result.substring(classEnd);
+    searchFrom = replaceStart + replacement.length;
+  }
+
+  return result;
+}
+
+function findMatchingClose(source: string, start: number): number {
+  const open = source[start];
+  const close = open === '(' ? ')' : open === '{' ? '}' : ']';
+  let depth = 1;
+  let pos = start + 1;
+
+  while (pos < source.length && depth > 0) {
+    const ch = source[pos];
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      pos++;
+      while (pos < source.length && source[pos] !== ch) {
+        if (source[pos] === '\\') pos++;
+        pos++;
+      }
+      pos++;
+      continue;
+    }
+
+    if (ch === '/' && pos + 1 < source.length && source[pos + 1] === '/') {
+      pos = source.indexOf('\n', pos);
+      if (pos === -1) return source.length;
+      pos++;
+      continue;
+    }
+
+    if (ch === '/' && pos + 1 < source.length && source[pos + 1] === '*') {
+      pos = source.indexOf('*/', pos + 2);
+      if (pos === -1) return source.length;
+      pos += 2;
+      continue;
+    }
+
+    if (ch === open) depth++;
+    else if (ch === close) depth--;
+    pos++;
+  }
+
+  return pos;
+}

--- a/build/plugins/local-externals.ts
+++ b/build/plugins/local-externals.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from 'esbuild';
+
+// Externalize local .ts imports and rewrite paths to .js
+export const localExternals: Plugin = {
+  name: 'local-externals',
+  setup(ctx) {
+    ctx.onResolve({ filter: /\.ts$/ }, (args) => {
+      if (args.kind === 'entry-point') return;
+      if (args.path.startsWith('.')) {
+        return {
+          path: args.path.replace(/\.ts$/, '.js'),
+          external: true,
+        };
+      }
+    });
+  },
+};

--- a/esbuild.ts
+++ b/esbuild.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from 'esbuild';
 import { build } from 'esbuild';
 import {
   copyFileSync,
@@ -12,6 +11,11 @@ import { fileURLToPath } from 'node:url';
 import AdmZip from 'adm-zip';
 import { format } from 'prettier';
 
+import { localExternals } from './build/plugins/local-externals.ts';
+import { createGirsResolver } from './build/plugins/girs-resolver.ts';
+import { gobjectDecorator } from './build/plugins/gobject-decorator.ts';
+import { addBlankLinesBetweenMembers } from './build/formatting.ts';
+
 interface ExtensionMetadata {
   name: string;
   version: string;
@@ -21,154 +25,6 @@ interface ExtensionMetadata {
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const metadataPath = resolve(currentDir, 'metadata.json');
 const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as ExtensionMetadata;
-
-// Externalize local .ts imports and rewrite paths to .js
-const localExternals: Plugin = {
-  name: 'local-externals',
-  setup(ctx) {
-    ctx.onResolve({ filter: /\.ts$/ }, (args) => {
-      if (args.kind === 'entry-point') return;
-      if (args.path.startsWith('.')) {
-        return {
-          path: args.path.replace(/\.ts$/, '.js'),
-          external: true,
-        };
-      }
-    });
-  },
-};
-
-// Resolve @girs/* imports directly to gi:// and resource:// runtime paths,
-// bypassing node_modules to avoid re-export shims and version query strings
-const girsResolver: Plugin = {
-  name: 'girs-resolver',
-  setup(ctx) {
-    // @girs/gjs is a type-only shim; drop it entirely
-    ctx.onResolve({ filter: /^@girs\/gjs$/ }, () => ({
-      path: 'gjs',
-      namespace: 'girs-empty',
-    }));
-    ctx.onLoad({ filter: /.*/, namespace: 'girs-empty' }, () => ({
-      contents: '',
-      loader: 'js',
-    }));
-
-    // @girs/gnome-shell/* → resource:///org/gnome/shell/*.js
-    ctx.onResolve({ filter: /^@girs\/gnome-shell\// }, (args) => {
-      const subpath = args.path.replace('@girs/gnome-shell/', '');
-      const distFile = resolve(
-        currentDir,
-        'node_modules/@girs/gnome-shell/dist',
-        `${subpath}.js`,
-      );
-      // Read the actual resource path from the package when the file exists,
-      // otherwise fall back to the standard resource path pattern
-      if (existsSync(distFile)) {
-        const content = readFileSync(distFile, 'utf8');
-        const match = content.match(/from ['"](.+)['"]/);
-        if (match) return { path: match[1], external: true };
-      }
-      return {
-        path: `resource:///org/gnome/shell/${subpath}.js`,
-        external: true,
-      };
-    });
-
-    // @girs/<name>-<version> → gi://<Namespace> (without ?version=)
-    ctx.onResolve({ filter: /^@girs\// }, (args) => {
-      if (args.path === '@girs/gjs' || args.path.startsWith('@girs/gnome-shell/'))
-        return;
-      const pkgName = args.path.replace('@girs/', '');
-      const mainFile = resolve(
-        currentDir,
-        `node_modules/@girs/${pkgName}/${pkgName}.js`,
-      );
-      if (existsSync(mainFile)) {
-        const content = readFileSync(mainFile, 'utf8');
-        const match = content.match(/from ["'](gi:\/\/[^?"']+)/);
-        if (match) return { path: match[1], external: true };
-      }
-    });
-  },
-};
-
-// JS keywords that should NOT be treated as method declarations
-const JS_KEYWORDS = new Set([
-  'if', 'for', 'while', 'switch', 'return', 'throw', 'try', 'catch',
-  'finally', 'else', 'do', 'new', 'typeof', 'void', 'delete', 'await',
-  'yield', 'debugger', 'with', 'break', 'continue', 'case', 'default',
-  'super', 'this', 'true', 'false', 'null', 'undefined',
-]);
-
-// Add blank lines between class methods, between the last field and first
-// method, and between top-level declarations. esbuild strips these blank
-// lines during compilation and prettier does not re-add them.
-function addBlankLinesBetweenMembers(code: string): string {
-  const lines = code.split('\n');
-  const result: string[] = [];
-
-  const isMethodDecl = (trimmed: string): boolean => {
-    const m = trimmed.match(
-      /^(?:(?:get |set |static |async )*([a-zA-Z_$#]\w*)\s*\()/,
-    );
-    return m !== null && !JS_KEYWORDS.has(m[1]);
-  };
-
-  const isComment = (trimmed: string): boolean =>
-    trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*');
-
-  for (let i = 0; i < lines.length; i++) {
-    if (i > 0 && lines[i].trim() !== '' && lines[i - 1].trim() !== '') {
-      const prev = lines[i - 1];
-      const curr = lines[i];
-      const prevTrimmed = prev.trimStart();
-      const currTrimmed = curr.trimStart();
-      const prevIndent = prev.search(/\S|$/);
-      const currIndent = curr.search(/\S|$/);
-      let needsBlank = false;
-
-      const isClosingBrace = /^\};?$/.test(prevTrimmed);
-
-      // Between methods: closing } at indent N → method decl at indent N
-      if (
-        isClosingBrace &&
-        currIndent === prevIndent &&
-        (isMethodDecl(currTrimmed) || isComment(currTrimmed))
-      ) {
-        needsBlank = true;
-      }
-
-      // Between last field and first method at the same indent level
-      if (
-        !needsBlank &&
-        /;$/.test(prevTrimmed) &&
-        /^[a-zA-Z_$#]\w*/.test(prevTrimmed) &&
-        currIndent === prevIndent &&
-        isMethodDecl(currTrimmed)
-      ) {
-        needsBlank = true;
-      }
-
-      // Between top-level declarations (indent 0) after block closures
-      if (
-        !needsBlank &&
-        currIndent === 0 &&
-        /[})\]];?\s*$/.test(prevTrimmed) &&
-        /^(?:var |let |const |function |class |export )/.test(currTrimmed)
-      ) {
-        needsBlank = true;
-      }
-
-      if (needsBlank) {
-        result.push('');
-      }
-    }
-
-    result.push(lines[i]);
-  }
-
-  return result.join('\n');
-}
 
 const srcDir = resolve(currentDir, 'src');
 const entryPoints = (readdirSync(srcDir, { recursive: true }) as string[])
@@ -181,7 +37,7 @@ const sharedOptions = {
   outdir: 'dist',
   outbase: 'src',
   bundle: true,
-  plugins: [localExternals, girsResolver],
+  plugins: [gobjectDecorator, localExternals, createGirsResolver(currentDir)],
   // Do not remove the functions `enable()`, `disable()` and `init()`
   treeShaking: false,
   // firefox60  // Since GJS 1.53.90

--- a/src/modules/dock.ts
+++ b/src/modules/dock.ts
@@ -56,9 +56,10 @@ type ManagedDockBinding = {
  * when the user pushes the pointer against the bottom edge, then emits
  * 'triggered' so the Dock module can reveal the dash.
  */
-const DockHotArea = GObject.registerClass({
+@GObject.registerClass({
   Signals: { triggered: {} },
-}, class DockHotArea extends St.Widget {
+})
+class DockHotArea extends St.Widget {
   private _pressureBarrier: any;
   private _horizontalBarrier: Meta.Barrier | null = null;
   private _triggerAllowed = true;
@@ -140,7 +141,7 @@ const DockHotArea = GObject.registerClass({
     this._horizontalBarrier.destroy();
     this._horizontalBarrier = null;
   }
-});
+}
 
 // -- Intellihide --
 
@@ -150,9 +151,10 @@ const DockHotArea = GObject.registerClass({
  * Emits 'status-changed' whenever the overlap state transitions between
  * CLEAR and BLOCKED so the Dock module can show/hide the dash accordingly.
  */
-const DockIntellihide = GObject.registerClass({
+@GObject.registerClass({
   Signals: { 'status-changed': {} },
-}, class DockIntellihide extends GObject.Object {
+})
+class DockIntellihide extends GObject.Object {
   private declare _monitorIndex: number;
   private declare _tracker: Shell.WindowTracker | null;
   private _targetBox: DashBounds | null = null;
@@ -293,7 +295,7 @@ const DockIntellihide = GObject.registerClass({
     this._applyOverlap(Main.keyboard.visible, true);
     if (!Main.keyboard.visible) this._checkOverlap();
   }
-});
+}
 
 // -- Dock Module --
 

--- a/src/ui/dash.ts
+++ b/src/ui/dash.ts
@@ -40,8 +40,8 @@ interface AuroraDashParams {
  * - The **dash** (this widget) always sits at local y=0 inside the container.
  *   Show/hide animations use `translation_y` only — never modify `this.y`.
  */
-export const AuroraDash = GObject.registerClass(
-class AuroraDashClass extends Dash {
+@GObject.registerClass
+export class AuroraDash extends Dash {
   private declare _monitorIndex: number;
   private _workArea: DashBounds | null = null;
   private _container: St.Bin | null = null;
@@ -666,9 +666,7 @@ class AuroraDashClass extends Dash {
     this._clearTimeout('_blockAutoHideDelayId');
     this._clearTimeout('_workAreaUpdateId');
   }
-});
-
-export type AuroraDash = InstanceType<typeof AuroraDash>;
+}
 
 function boundsEqual(a: DashBounds | null, b: DashBounds | null): boolean {
   if (a === b) return true;


### PR DESCRIPTION
This pull request refactors the build system by modularizing esbuild plugins into separate files, introduces new build plugins for GObject decorator transformation and improved formatting, and updates class declarations in the source code to use decorator syntax. These changes improve code maintainability, enable cleaner source syntax, and enhance the build output formatting.

* Extracted esbuild plugins (`localExternals`, `girs-resolver`, `gobjectDecorator`, and `addBlankLinesBetweenMembers`) from `esbuild.ts` into dedicated files under `build/plugins/` and `build/formatting.ts`, improving maintainability and separation of concerns.
 
* Introduced the `gobjectDecorator` plugin to transform `@GObject.registerClass` decorators into `GObject.registerClass()` calls, enabling cleaner decorator syntax in TypeScript source files and compatibility with GJS runtime requirements.
 
* Added the `addBlankLinesBetweenMembers` function to ensure that blank lines are inserted between class methods, fields, and top-level declarations, enhancing readability of compiled output.

* Refactored class declarations in `src/modules/dock.ts` and `src/ui/dash.ts` to use `@GObject.registerClass` decorator syntax, aligning with the new build plugin and simplifying class registration.