### PR TITLE
fix(noOverview): update module to prevent overview from showing at startup

### DIFF
--- a/src/modules/noOverview.ts
+++ b/src/modules/noOverview.ts
@@ -4,20 +4,28 @@ import { Module } from '../module.ts';
 
 /**
  * NoOverview Module
- * 
- * Automatically hides the GNOME Overview on startup.
- * This provides a cleaner desktop experience for users who prefer not to use the overview.
- * Note: This module only hides the overview on startup. Users can still access it via hotkeys or gestures.
+ *
+ * Prevents the GNOME Overview from showing at startup by temporarily disabling
+ * `sessionMode.hasOverview`, which causes the startup animation to skip the
+ * overview transition entirely. Once startup completes, `hasOverview` is restored
+ * so the overview remains accessible via hotkeys, gestures, and the Activities button.
  */
 export class NoOverview extends Module {
   override enable(): void {
+    if (!Main.layoutManager._startingUp) return;
+
+    Main.sessionMode.hasOverview = false;
+
     Main.layoutManager.connectObject(
-      'startup-complete', () => Main.overview.hide(),
+      'startup-complete', () => {
+        Main.sessionMode.hasOverview = true;
+      },
       this
     );
   }
 
   override disable(): void {
+    Main.sessionMode.hasOverview = true;
     Main.layoutManager.disconnectObject(this);
   }
 }


### PR DESCRIPTION
This pull request fix #5. Instead of hiding the overview after it appears, the module now temporarily disables the overview entirely during startup, and restores it once startup is complete. This ensures the overview transition is skipped, while keeping it accessible afterwards.

* Temporarily sets `Main.sessionMode.hasOverview` to `false` during startup to prevent the overview from showing, then restores it to `true` after startup completes. This skips the overview transition animation and avoids the need to hide the overview post-startup.
* Ensures that disabling the module always restores `Main.sessionMode.hasOverview` to `true`, maintaining consistent behavior if the module is toggled.