### PR TITLE
feat: add DND on Screen Share module to automatically enable Do Not Disturb during screen sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Aurora is split into independent modules, so you can enable only what you want.
 | **Dock** | Replaces the stock dash with a smart per-monitor dock with intellihide and edge reveal |
 | **Volume Mixer** | Adds per-application volume sliders to Quick Settings with fast access to Sound Settings |
 | **XWayland Indicator** | Adds an indicator to the app activities in Ctrl + Tab to indicate where XWayland is running |
+| **DND on Screen Share** | Automatically enables Do Not Disturb mode when screen sharing or recording is active |
 
 All modules can be toggled independently from the extension preferences.
 
@@ -57,76 +58,6 @@ just create-toolbox   # first time only
 just toolbox-run
 ```
 
-## Adding a Module
+## Contributing
 
-Adding a module is quick. You wire it in once, and Aurora handles lifecycle + preferences automatically.
-
-1. Create your module file at `src/modules/myModule.ts`.
-
-```typescript
-import { Module } from '~/module.ts';
-
-export class MyModule extends Module {
-  override enable(): void {
-    // setup
-  }
-
-  override disable(): void {
-    // cleanup (mirror enable)
-  }
-}
-```
-
-2. Register the module in `src/registry.ts` so it appears in Preferences.
-
-```typescript
-// Inside getModuleRegistry()
-{
-  key: 'my-module',
-  settingsKey: 'module-my-module',
-  title: _('My Module'),
-  subtitle: _('Short, user-facing description'),
-},
-```
-
-3. Add the module factory in `src/extension.ts`.
-
-```typescript
-import { MyModule } from '~/modules/myModule.ts';
-
-const MODULE_FACTORIES: Record<string, () => Module> = {
-  // ...existing entries...
-  'my-module': () => new MyModule(),
-};
-```
-
-4. Add a toggle key to `schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml`.
-
-```xml
-<key name="module-my-module" type="b">
-  <default>true</default>
-  <summary>Enable My Module</summary>
-  <description>What this module does</description>
-</key>
-```
-
-5. Build and verify.
-
-```bash
-just build
-```
-
-After that, your module should appear in Preferences and respect runtime enable/disable.
-
-## Build System
-
-- **esbuild** bundles TypeScript (target: Firefox 102 / GJS 1.73.2+, format: ESM)
-- **Sass** compiles SCSS stylesheets (light + dark variants)
-- **AdmZip** packages the extension as a `.zip` for distribution
-
-## Code Style
-
-- Files: `camelCase.ts`
-- Classes: `PascalCase`
-- Private members: `_prefixed`
-- Constants: `UPPER_CASE`
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for information on project architecture, code style, and step-by-step instructions on how to add a new module.

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -31,5 +31,10 @@
       <summary>Enable XWayland Indicator module</summary>
       <description>Shows an X11 badge on XWayland apps in the Alt+Tab switcher</description>
     </key>
+    <key name="module-dnd-on-share" type="b">
+      <default>true</default>
+      <summary>Enable DND on Screen Share module</summary>
+      <description>Automatically enables Do Not Disturb mode when screen sharing</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { ThemeChanger } from "~/modules/themeChanger.ts";
 import { Dock } from "~/modules/dock/dock.ts";
 import { VolumeMixer } from "~/modules/volumeMixer/volumeMixer.ts";
 import { XwaylandIndicator } from "~/modules/xwaylandIndicator.ts";
+import { DndOnShare } from "~/modules/dndOnShare.ts";
 
 const MODULE_FACTORIES: Record<string, () => Module> = {
   'no-overview': () => new NoOverview(),
@@ -21,6 +22,7 @@ const MODULE_FACTORIES: Record<string, () => Module> = {
   'dock': () => new Dock(),
   'volume-mixer': () => new VolumeMixer(),
   'xwayland-indicator': () => new XwaylandIndicator(),
+  'dnd-on-share': () => new DndOnShare(),
 };
 
 /**

--- a/src/modules/dndOnShare.ts
+++ b/src/modules/dndOnShare.ts
@@ -1,0 +1,73 @@
+import { Module } from '../module.ts';
+import * as Main from '@girs/gnome-shell/ui/main';
+import Gio from '@girs/gio-2.0';
+
+const NOTIFICATIONS_SCHEMA = 'org.gnome.desktop.notifications';
+const SHOW_BANNERS_KEY = 'show-banners';
+
+export class DndOnShare extends Module {
+  private _notificationsSettings: Gio.Settings | null = null;
+  private _savedShowBannersState: boolean | null = null;
+
+  private _getSharingIndicator(): any | null {
+    const statusArea = Main.panel.statusArea as any;
+
+    // GNOME Shell 49+: dedicated panel indicator for screen sharing.
+    if (statusArea.screenSharing) return statusArea.screenSharing;
+
+    // Backward-compatible fallback for older shells/extensions.
+    return statusArea.quickSettings?._remoteAccess ?? null;
+  }
+
+  override enable(): void {
+    const indicator = this._getSharingIndicator();
+
+    if (indicator) {
+      this._notificationsSettings = new Gio.Settings({ schema_id: NOTIFICATIONS_SCHEMA });
+      
+      (indicator as any).connectObject('notify::visible', () => {
+        this._syncDndState(indicator.visible);
+      }, this);
+
+      if (indicator.visible) {
+        this._syncDndState(true);
+      }
+    } else {
+      console.warn('[aurora-shell] Screen sharing indicator not found for DndOnShare module');
+    }
+  }
+
+  override disable(): void {
+    const indicator = this._getSharingIndicator();
+    if (indicator) {
+      (indicator as any).disconnectObject?.(this);
+    }
+    
+    this._restoreState();
+    this._notificationsSettings = null;
+  }
+
+  private _syncDndState(isSharing: boolean): void {
+    if (!this._notificationsSettings) return;
+
+    if (isSharing) {
+      const isCurrentlyShowingBanners = this._notificationsSettings.get_boolean(SHOW_BANNERS_KEY);
+      
+      if (isCurrentlyShowingBanners) {
+        this._savedShowBannersState = true;
+        this._notificationsSettings.set_boolean(SHOW_BANNERS_KEY, false);
+      } else {
+        this._savedShowBannersState = null;
+      }
+    } else {
+      this._restoreState();
+    }
+  }
+
+  private _restoreState(): void {
+    if (this._notificationsSettings && this._savedShowBannersState !== null) {
+      this._notificationsSettings.set_boolean(SHOW_BANNERS_KEY, this._savedShowBannersState);
+      this._savedShowBannersState = null;
+    }
+  }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -45,5 +45,11 @@ export function getModuleRegistry(): ModuleDefinition[] {
       title: _('XWayland Indicator'),
       subtitle: _('Shows an X11 badge on XWayland apps in the Alt+Tab switcher'),
     },
+    {
+      key: 'dnd-on-share',
+      settingsKey: 'module-dnd-on-share',
+      title: _('DND on Screen Share'),
+      subtitle: _('Automatically enables Do Not Disturb mode when screen sharing'),
+    },
   ];
 }


### PR DESCRIPTION
When the system is sharing the screen, the "Do Not Disturb" option is enabled to not show your personal notifications on screen.