### PR TITLE
fix: Fix the dock drag'n drop state and clear some stufs for GNOME 50 support

### DIFF
--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -56,7 +56,6 @@ export class AuroraDash extends Dash {
   private _workAreaUpdateId = 0;
   private _targetBox: DashBounds | null = null;
   private _blockAutoHide = false;
-  private _draggingItem = false;
   private _isDestroyed = false;
   private _targetBoxListener: TargetBoxListener | null = null;
   private _pendingShow: { animate: boolean; onComplete?: () => void } | null = null;
@@ -70,25 +69,6 @@ export class AuroraDash extends Dash {
     const button = (this as any).showAppsButton;
     button?.set_toggle_mode?.(false);
     button?.connectObject?.('clicked', () => Main.overview.showApps(), this);
-
-    // Track drag state so the dock stays visible while dragging items.
-    Main.overview.connectObject(
-      'item-drag-begin', () => {
-        this._draggingItem = true;
-        this._onHover();
-      },
-      'item-drag-end', () => {
-        this._draggingItem = false;
-        this._onHover();
-        if (this._workArea) this.applyWorkArea(this._workArea);
-      },
-      'item-drag-cancelled', () => {
-        this._draggingItem = false;
-        this._onHover();
-        if (this._workArea) this.applyWorkArea(this._workArea);
-      },
-      this
-    );
 
     const dashContainer = (this as unknown as { _dashContainer?: St.Widget })._dashContainer;
     dashContainer?.set_track_hover?.(true);
@@ -133,11 +113,6 @@ export class AuroraDash extends Dash {
   override destroy(): void {
     this._isDestroyed = true;
     this._clearAllTimeouts();
-
-    // Remove the parent Dash's drag monitor if a DnD session is in progress.
-    // Without this, dnd.js continues firing callbacks into the disposed object.
-    const dragMonitor = (this as any)._dragMonitor;
-    if (dragMonitor) DND.removeDragMonitor(dragMonitor);
 
     (this as any).showAppsButton?.disconnectObject?.(this);
     this.disconnectObject?.(this);
@@ -617,14 +592,14 @@ export class AuroraDash extends Dash {
     }
   }
 
-  /** Start or restart the autohide timeout — hides the dock if not hovered/dragging/blocked. */
+  /** Start or restart the autohide timeout — hides the dock if not hovered/blocked. */
   private _onHover(): void {
     if (this._isDestroyed) return;
     this._clearTimeout('_autohideTimeoutId');
     this._autohideTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, AUTOHIDE_TIMEOUT, () => {
       const dashContainer = (this as any)._dashContainer as St.Widget | undefined;
 
-      if (dashContainer?.get_hover?.() || this._draggingItem || this._blockAutoHide || this._isMenuOpen()) {
+      if (dashContainer?.get_hover?.() || this._blockAutoHide || this._isMenuOpen()) {
         return GLib.SOURCE_CONTINUE;
       }
 

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -27,7 +27,6 @@ const VISIBILITY_ANIMATION_TIME = 200;
 const HIDE_SCALE = 0.98;
 const EASE_DURATION_FACTOR = 0.8;
 const FULL_OPACITY = 255;
-const CLEAR_PLACEHOLDER_DELAY = 60;
 const PIVOT_CENTER_BOTTOM: [number, number] = [0.5, 1];
 
 interface AuroraDashParams {
@@ -58,12 +57,6 @@ export class AuroraDash extends Dash {
   private _targetBox: DashBounds | null = null;
   private _blockAutoHide = false;
   private _draggingItem = false;
-  private _dndMonitor: { dragMotion: (e: any) => any; dragDrop: (e: any) => any } | null = null;
-  private _clearPlaceholderTimerId = 0;
-  /** Stage-X of _box, frozen while a placeholder exists so slot math stays consistent across frames. */
-  private _dndBoxOriginX = 0;
-  private _dndDropHandled = false;
-  private _savedDndSource: any = null;
   private _isDestroyed = false;
   private _targetBoxListener: TargetBoxListener | null = null;
   private _pendingShow: { animate: boolean; onComplete?: () => void } | null = null;
@@ -79,26 +72,20 @@ export class AuroraDash extends Dash {
     button?.connectObject?.('clicked', () => Main.overview.showApps(), this);
 
     // Track drag state so the dock stays visible while dragging items.
-    // Also install a dock-specific drag monitor to bridge the DnD gap: GNOME's
-    // dnd.js finds drop targets by traversing the drag actor's parent chain,
-    // which ends at Main.uiGroup and never reaches the dock's _box._delegate.
-    // The drag monitor calls handleDragOver/acceptDrop directly instead.
     Main.overview.connectObject(
-      'item-drag-begin', (_ov: any, source: any) => {
+      'item-drag-begin', () => {
         this._draggingItem = true;
-        this._dndDropHandled = false;
         this._onHover();
-        this._setupDnd(source);
       },
       'item-drag-end', () => {
         this._draggingItem = false;
         this._onHover();
-        this._teardownDnd();
+        if (this._workArea) this.applyWorkArea(this._workArea);
       },
       'item-drag-cancelled', () => {
         this._draggingItem = false;
         this._onHover();
-        this._teardownDnd();
+        if (this._workArea) this.applyWorkArea(this._workArea);
       },
       this
     );
@@ -151,15 +138,6 @@ export class AuroraDash extends Dash {
     // Without this, dnd.js continues firing callbacks into the disposed object.
     const dragMonitor = (this as any)._dragMonitor;
     if (dragMonitor) DND.removeDragMonitor(dragMonitor);
-
-    if (this._dndMonitor) DND.removeDragMonitor(this._dndMonitor);
-    this._dndMonitor = null;
-    if (this._clearPlaceholderTimerId) {
-      GLib.source_remove(this._clearPlaceholderTimerId);
-      this._clearPlaceholderTimerId = 0;
-    }
-    this._savedDndSource = null;
-    this._restoreClearDragPlaceholder();
 
     (this as any).showAppsButton?.disconnectObject?.(this);
     this.disconnectObject?.(this);
@@ -218,7 +196,6 @@ export class AuroraDash extends Dash {
 
   applyWorkArea(workArea: DashBounds): void {
     this._workArea = workArea;
-    if (this._draggingItem) return;
     if (!this._container) return;
 
     const [, prefW] = this.get_preferred_width(workArea.width);
@@ -404,15 +381,10 @@ export class AuroraDash extends Dash {
     (Dash.prototype as any)._onWindowDragEnd?.call(this, ...args);
   }
 
-  /**
-   * Guard acceptDrop so we can detect when the normal actor-traversal path
-   * succeeds (overview context). `_dndDropHandled` is set here so a
-   * drag-monitor drop doesn't reorder twice.
-   */
-  override acceptDrop(...args: any[]): boolean {
-    if (this._isDestroyed) return false;
-    const result = (Dash.prototype as any).acceptDrop?.call(this, ...args) ?? false;
-    if (result) this._dndDropHandled = true;
+  override handleDragOver(...args: any[]): any {
+    if (this._isDestroyed) return (this as any).DragMotionResult?.CONTINUE ?? 1;
+    const result = (Dash.prototype as any).handleDragOver?.call(this, ...args);
+    this._queueWorkAreaUpdate();
     return result;
   }
 
@@ -458,7 +430,7 @@ export class AuroraDash extends Dash {
 
     if (dashAny.iconSize !== oldIconSize) {
       this._animateIconResize();
-    } else if (this._workArea && !this._draggingItem) {
+    } else if (this._workArea) {
       // Defer the work-area resize so newly-added icon containers have
       // completed their initial layout pass and report accurate preferred
       // sizes. Without this, the container can be sized too small and the
@@ -762,199 +734,6 @@ export class AuroraDash extends Dash {
       }
       return GLib.SOURCE_REMOVE;
     });
-  }
-
-  /**
-   * Install a drag monitor and pre-expand the container for one drag session.
-   *
-   * ## Stable slot calculation
-   * We track `_dndBoxOriginX` = the stage-X of `_box`. While no placeholder
-   * exists the origin is refreshed every dragMotion frame (the box is stable).
-   * The origin `_dndBoxOriginX` is frozen at the pre-drag value of `_box`'s
-   * stage-X while a placeholder exists, and refreshed per-frame when the box
-   * is stable (no placeholder). This works because `handleDragOver` always
-   * subtracts `placeholder.width` from `boxWidth`, making:
-   *   boxWidth_adj = _box.width − placeholder.width = origBoxW
-   * so `pos = floor((event.x − _dndBoxOriginX) × N / origBoxW)` is identical
-   * in all frames — no analytical correction is needed.
-   *
-   * On first placeholder insertion we cancel its fade-in animation immediately
-   * so the layout settles in a single frame.
-   */
-  private _setupDnd(_source: any): void {
-    if (this._dndMonitor) return;
-
-    this._savedDndSource = null;
-    this._dndDropHandled = false;
-
-    // Capture initial origin and pre-expand the container.
-    const box = (this as any)._box;
-    this._dndBoxOriginX = (box?.get_transformed_position?.() ?? [0])[0];
-    this._preExpandContainer();
-    this._patchClearDragPlaceholder();
-
-    this._dndMonitor = {
-      dragMotion: (event: any) => this._dndDragMotion(event),
-      dragDrop: (event: any) => this._dndDragDrop(event),
-    };
-    DND.addDragMonitor(this._dndMonitor);
-  }
-
-  private _teardownDnd(): void {
-    if (this._dndMonitor) {
-      DND.removeDragMonitor(this._dndMonitor);
-      this._dndMonitor = null;
-    }
-    this._cancelClearPlaceholderTimer();
-    this._restoreClearDragPlaceholder();
-    this._savedDndSource = null;
-    this._dndDropHandled = false;
-    if (this._workArea) this.applyWorkArea(this._workArea);
-  }
-
-  private _dndDragMotion(event: any): any {
-    if (this._isDestroyed) return DND.DragMotionResult.CONTINUE;
-
-    const container = this._container;
-    const box = (this as any)._box;
-    if (!container || !box) return DND.DragMotionResult.CONTINUE;
-
-    // Bounds check against the pre-expanded, position-stable container.
-    const [ok, contLocalX, contLocalY] = (container as any).transform_stage_point(event.x, event.y);
-    if (!ok) return DND.DragMotionResult.CONTINUE;
-
-    const [contW, contH] = (container as any).get_size();
-    if (contLocalX < 0 || contLocalX > contW || contLocalY < 0 || contLocalY > contH) {
-      this._scheduleClearPlaceholder();
-      return DND.DragMotionResult.CONTINUE;
-    }
-
-    this._cancelClearPlaceholderTimer();
-
-    // Refresh _box origin only while no placeholder exists (box is stable).
-    // While a placeholder is present, `handleDragOver` self-normalizes:
-    // boxWidth_adj = _box.width − placeholder.width = origBoxW, so the frozen
-    // origin keeps pos consistent across all frames without any correction.
-    const dashAny = this as any;
-    if (!dashAny._dragPlaceholder) {
-      this._dndBoxOriginX = (box.get_transformed_position?.() ?? [0])[0];
-    }
-
-    const hadPlaceholder = dashAny._dragPlaceholder !== null;
-    const localX = event.x - this._dndBoxOriginX;
-
-    const result =
-      (Dash.prototype as any).handleDragOver?.call(this, event.source, event.dragActor, localX, contLocalY, 0) ??
-      DND.DragMotionResult.CONTINUE;
-
-    // On first insertion: cancel fade-in animation so the layout settles
-    // immediately in a single frame rather than over ~200 ms.
-    if (!hadPlaceholder && dashAny._dragPlaceholder?.child) {
-      dashAny._dragPlaceholder.child.remove_all_transitions?.();
-      dashAny._dragPlaceholder.child.set_width(dashAny.iconSize);
-    }
-
-    if (result === DND.DragMotionResult.MOVE_DROP) {
-      this._savedDndSource = event.source;
-    }
-
-    return result;
-  }
-
-  /**
-   * On drop: patch targetActor._delegate so dnd.js actor-traversal reaches
-   * our acceptDrop. Returning CONTINUE lets dnd.js perform its own cleanup
-   * (removes drag actor, emits drag-end, restores cursor).
-   */
-  private _dndDragDrop(event: any): any {
-    if (this._isDestroyed) return DND.DragDropResult.CONTINUE;
-
-    const container = this._container;
-    if (!container || !this._savedDndSource) return DND.DragDropResult.CONTINUE;
-
-    const [cx, cy] = event.clutterEvent?.get_coords?.() ?? [0, 0];
-    const [ok, localX, localY] = (container as any).transform_stage_point(cx, cy);
-    if (!ok) return DND.DragDropResult.CONTINUE;
-
-    const [cW, cH] = (container as any).get_size();
-    if (localX < 0 || localX > cW || localY < 0 || localY > cH) return DND.DragDropResult.CONTINUE;
-
-    const targetActor = event.targetActor;
-    if (targetActor) {
-      const origDelegate = targetActor._delegate;
-      targetActor._delegate = {
-        acceptDrop: (source: any, actor: any, x: number, y: number, time: number) => {
-          targetActor._delegate = origDelegate;
-          const accepted = (Dash.prototype as any).acceptDrop?.call(this, source, actor, x, y, time) ?? false;
-          if (accepted) this._dndDropHandled = true;
-          return accepted;
-        },
-      };
-    }
-
-    return DND.DragDropResult.CONTINUE;
-  }
-
-  /** Pre-expand the container by one icon-slot width before the drag monitor activates. */
-  private _preExpandContainer(): void {
-    if (!this._container || !this._workArea) return;
-
-    const dashAny = this as any;
-    const firstChild = (dashAny._box?.get_children?.() ?? [])[0];
-    const slotWidth =
-      Math.ceil((firstChild?.get_size?.() ?? [0, 0])[0]) ||
-      (dashAny.iconSize ?? 48) + 24;
-
-    const wa = this._workArea;
-    const [, prefW] = this.get_preferred_width(wa.width);
-    const curW = Math.min(Math.max(prefW, 0), wa.width);
-    const expandedW = Math.min(curW + slotWidth, wa.width);
-    const expandedX = wa.x + Math.round((wa.width - expandedW) / 2);
-    const [, prefH] = this.get_preferred_height(expandedW);
-    const expandedH = Math.min(Math.max(prefH, 0), wa.height);
-    const marginBottom = this._getMarginBottom();
-    const expandedY = Math.max(wa.y, wa.y + wa.height - expandedH - marginBottom);
-
-    this._container.set_size(expandedW, expandedH);
-    this._container.set_position(expandedX, expandedY);
-  }
-
-  /**
-   * Replace `_clearDragPlaceholder` on the instance to destroy the placeholder
-   * immediately (no animate-out). This keeps `_animatingPlaceholdersCount` at 0
-   * so `handleDragOver` never enters its ~200 ms locked state.
-   */
-  private _patchClearDragPlaceholder(): void {
-    const dashAny = this as any;
-    dashAny._clearDragPlaceholder = () => {
-      if (dashAny._dragPlaceholder) {
-        dashAny._dragPlaceholder.remove_all_transitions?.();
-        dashAny._dragPlaceholder.child?.remove_all_transitions?.();
-        dashAny._dragPlaceholder.destroy();
-        dashAny._dragPlaceholder = null;
-      }
-      dashAny._dragPlaceholderPos = -1;
-    };
-  }
-
-  private _restoreClearDragPlaceholder(): void {
-    delete (this as any)._clearDragPlaceholder;
-  }
-
-  private _scheduleClearPlaceholder(): void {
-    if (this._clearPlaceholderTimerId) return;
-    this._clearPlaceholderTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, CLEAR_PLACEHOLDER_DELAY, () => {
-      this._clearPlaceholderTimerId = 0;
-      if (!this._isDestroyed) (this as any)._clearDragPlaceholder?.();
-      return GLib.SOURCE_REMOVE;
-    });
-  }
-
-  private _cancelClearPlaceholderTimer(): void {
-    if (this._clearPlaceholderTimerId) {
-      GLib.source_remove(this._clearPlaceholderTimerId);
-      this._clearPlaceholderTimerId = 0;
-    }
   }
 
   private _clearTimeout(prop: TimeoutProp): void {

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -19,12 +19,16 @@ export interface DashBounds {
 const TARGET_BOX_PADDING = 8;
 
 type TargetBoxListener = (bounds: DashBounds | null) => void;
+type TimeoutProp = '_autohideTimeoutId' | '_delayEnsureAutoHideId' | '_blockAutoHideDelayId' | '_workAreaUpdateId';
 
 const AUTOHIDE_TIMEOUT = 100;
 const ANIMATION_TIME = 200;
 const VISIBILITY_ANIMATION_TIME = 200;
 const HIDE_SCALE = 0.98;
 const EASE_DURATION_FACTOR = 0.8;
+const FULL_OPACITY = 255;
+const CLEAR_PLACEHOLDER_DELAY = 60;
+const PIVOT_CENTER_BOTTOM: [number, number] = [0.5, 1];
 
 interface AuroraDashParams {
   monitorIndex?: number;
@@ -54,10 +58,15 @@ export class AuroraDash extends Dash {
   private _targetBox: DashBounds | null = null;
   private _blockAutoHide = false;
   private _draggingItem = false;
+  private _dndMonitor: { dragMotion: (e: any) => any; dragDrop: (e: any) => any } | null = null;
+  private _clearPlaceholderTimerId = 0;
+  /** Stage-X of _box, frozen while a placeholder exists so slot math stays consistent across frames. */
+  private _dndBoxOriginX = 0;
+  private _dndDropHandled = false;
+  private _savedDndSource: any = null;
   private _isDestroyed = false;
   private _targetBoxListener: TargetBoxListener | null = null;
   private _pendingShow: { animate: boolean; onComplete?: () => void } | null = null;
-  private _cycleState: { appId: string; windows: any[]; index: number } | null = null;
 
   _init(params: AuroraDashParams = {}): void {
     super._init();
@@ -69,10 +78,28 @@ export class AuroraDash extends Dash {
     button?.set_toggle_mode?.(false);
     button?.connectObject?.('clicked', () => Main.overview.showApps(), this);
 
-    // Track drag state so the dock stays visible while dragging items
+    // Track drag state so the dock stays visible while dragging items.
+    // Also install a dock-specific drag monitor to bridge the DnD gap: GNOME's
+    // dnd.js finds drop targets by traversing the drag actor's parent chain,
+    // which ends at Main.uiGroup and never reaches the dock's _box._delegate.
+    // The drag monitor calls handleDragOver/acceptDrop directly instead.
     Main.overview.connectObject(
-      'item-drag-begin', () => { this._draggingItem = true; this._onHover(); },
-      'item-drag-end', () => { this._draggingItem = false; this._onHover(); },
+      'item-drag-begin', (_ov: any, source: any) => {
+        this._draggingItem = true;
+        this._dndDropHandled = false;
+        this._onHover();
+        this._setupDnd(source);
+      },
+      'item-drag-end', () => {
+        this._draggingItem = false;
+        this._onHover();
+        this._teardownDnd();
+      },
+      'item-drag-cancelled', () => {
+        this._draggingItem = false;
+        this._onHover();
+        this._teardownDnd();
+      },
       this
     );
 
@@ -125,6 +152,15 @@ export class AuroraDash extends Dash {
     const dragMonitor = (this as any)._dragMonitor;
     if (dragMonitor) DND.removeDragMonitor(dragMonitor);
 
+    if (this._dndMonitor) DND.removeDragMonitor(this._dndMonitor);
+    this._dndMonitor = null;
+    if (this._clearPlaceholderTimerId) {
+      GLib.source_remove(this._clearPlaceholderTimerId);
+      this._clearPlaceholderTimerId = 0;
+    }
+    this._savedDndSource = null;
+    this._restoreClearDragPlaceholder();
+
     (this as any).showAppsButton?.disconnectObject?.(this);
     this.disconnectObject?.(this);
     Main.overview.disconnectObject(this);
@@ -136,7 +172,6 @@ export class AuroraDash extends Dash {
     this._container = null;
     this._targetBox = null;
     this._pendingShow = null;
-    this._cycleState = null;
 
     super.destroy();
   }
@@ -183,6 +218,7 @@ export class AuroraDash extends Dash {
 
   applyWorkArea(workArea: DashBounds): void {
     this._workArea = workArea;
+    if (this._draggingItem) return;
     if (!this._container) return;
 
     const [, prefW] = this.get_preferred_width(workArea.width);
@@ -237,7 +273,7 @@ export class AuroraDash extends Dash {
     if (this._isFullyHidden()) return;
 
     this.remove_all_transitions();
-    this.set_pivot_point(0.5, 1);
+    this.set_pivot_point(...PIVOT_CENTER_BOTTOM);
 
     if (!animate) {
       this._applyHiddenState();
@@ -263,20 +299,20 @@ export class AuroraDash extends Dash {
   private _isMenuOpen(): boolean {
     const dashAny = this as any;
     const children = dashAny._box?.get_children?.() ?? [];
-    
+
     for (const child of children) {
       const appIcon = child.child?._delegate;
-      
+
       if (appIcon?._menu?.isOpen) {
         return true;
       }
     }
-    
+
     const showApps = dashAny.showAppsButton || dashAny._showAppsIcon?._delegate;
     if (showApps?._menu?.isOpen) {
       return true;
     }
-    
+
     return false;
   }
 
@@ -298,7 +334,7 @@ export class AuroraDash extends Dash {
     // actor at a stale position (avoids "needs an allocation" warnings and
     // prevents _queueTargetBoxUpdate from reading a wrong transformed Y).
     this.remove_all_transitions();
-    this.set_pivot_point(0.5, 1);
+    this.set_pivot_point(...PIVOT_CENTER_BOTTOM);
 
     if (!animate) {
       this._applyShownState();
@@ -312,7 +348,7 @@ export class AuroraDash extends Dash {
     super.show();
 
     this.ease({
-      opacity: 255,
+      opacity: FULL_OPACITY,
       scale_x: 1,
       scale_y: 1,
       duration: VISIBILITY_ANIMATION_TIME,
@@ -329,7 +365,7 @@ export class AuroraDash extends Dash {
   /** Set transform properties to the fully-visible resting state. */
   private _applyShownState(): void {
     this.translation_y = 0;
-    this.opacity = 255;
+    this.opacity = FULL_OPACITY;
     this.set_scale(1, 1);
   }
 
@@ -340,43 +376,44 @@ export class AuroraDash extends Dash {
     this.set_scale(HIDE_SCALE, HIDE_SCALE);
   }
 
-  /**
-   * Guard wrappers for parent Dash signal handlers that fire during DnD in the
-   * overview workspace view. If GNOME Shell 50's Dash.destroy() fails to
-   * disconnect a signal, the bound handler still reaches here via the prototype
-   * chain. Returning early prevents any GObject property access on the already-
-   * disposed object (JS-object properties such as _isDestroyed remain readable
-   * after GObject disposal).
-   */
-  _onDragBegin(): void {
+  // Dash._init() connects these via bare connect() (not connectObject), so they keep firing after
+  // destroy(). Guard them so signals don't reach a disposed object.
+
+  override _onItemDragBegin(): void {
     if (this._isDestroyed) return;
-    (Dash.prototype as any)._onDragBegin?.call(this);
+    (Dash.prototype as any)._onItemDragBegin?.call(this);
   }
 
-  _onDragEnd(): void {
+  override _onItemDragEnd(): void {
     if (this._isDestroyed) return;
-    (Dash.prototype as any)._onDragEnd?.call(this);
+    (Dash.prototype as any)._onItemDragEnd?.call(this);
   }
 
-  _onDragMotion(...args: any[]): any {
+  override _onItemDragCancelled(): void {
     if (this._isDestroyed) return;
-    return (Dash.prototype as any)._onDragMotion?.call(this, ...args);
+    (Dash.prototype as any)._onItemDragCancelled?.call(this);
   }
 
-  _onDragLeave(): void {
-    if (this._isDestroyed) return;
-    (Dash.prototype as any)._onDragLeave?.call(this);
-  }
-
-  // GNOME 50 added window-drag signals forwarded from the workspace view.
-  _onWindowDragBegin(...args: any[]): void {
+  override _onWindowDragBegin(...args: any[]): void {
     if (this._isDestroyed) return;
     (Dash.prototype as any)._onWindowDragBegin?.call(this, ...args);
   }
 
-  _onWindowDragEnd(...args: any[]): void {
+  override _onWindowDragEnd(...args: any[]): void {
     if (this._isDestroyed) return;
     (Dash.prototype as any)._onWindowDragEnd?.call(this, ...args);
+  }
+
+  /**
+   * Guard acceptDrop so we can detect when the normal actor-traversal path
+   * succeeds (overview context). `_dndDropHandled` is set here so a
+   * drag-monitor drop doesn't reorder twice.
+   */
+  override acceptDrop(...args: any[]): boolean {
+    if (this._isDestroyed) return false;
+    const result = (Dash.prototype as any).acceptDrop?.call(this, ...args) ?? false;
+    if (result) this._dndDropHandled = true;
+    return result;
   }
 
   /**
@@ -385,7 +422,7 @@ export class AuroraDash extends Dash {
    * after animation). Otherwise, re-apply the work area immediately so the
    * container grows/shrinks to fit added or removed icons.
    */
-  private _redisplay(): void {
+  override _redisplay(): void {
     if (this._isDestroyed) return;
     const dashAny = this as any;
     const oldIconSize = dashAny.iconSize;
@@ -402,12 +439,13 @@ export class AuroraDash extends Dash {
           app.get_windows().some(isRelevant)
         );
       };
-    }
-
-    Dash.prototype._redisplay.call(this);
-
-    if (appSystem && origGetRunning) {
-      appSystem.get_running = origGetRunning;
+      try {
+        Dash.prototype._redisplay.call(this);
+      } finally {
+        appSystem.get_running = origGetRunning;
+      }
+    } else {
+      Dash.prototype._redisplay.call(this);
     }
 
     // Update running-indicator dots for favorites: hide the dot when the
@@ -420,7 +458,7 @@ export class AuroraDash extends Dash {
 
     if (dashAny.iconSize !== oldIconSize) {
       this._animateIconResize();
-    } else if (this._workArea) {
+    } else if (this._workArea && !this._draggingItem) {
       // Defer the work-area resize so newly-added icon containers have
       // completed their initial layout pass and report accurate preferred
       // sizes. Without this, the container can be sized too small and the
@@ -482,6 +520,7 @@ export class AuroraDash extends Dash {
       const isRelevant = (w: any) => this._isWindowRelevant(w);
 
       appIcon.activate = function (button: number) {
+        // `this` is appIcon here — _cycleState is stored per icon, not on AuroraDash.
         // Ctrl+click or middle-click opens a new window — keep default behavior
         const event = Clutter.get_current_event();
         const modifiers = event ? event.get_state() : 0;
@@ -612,11 +651,11 @@ export class AuroraDash extends Dash {
     this._clearTimeout('_autohideTimeoutId');
     this._autohideTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, AUTOHIDE_TIMEOUT, () => {
       const dashContainer = (this as any)._dashContainer as St.Widget | undefined;
-      
+
       if (dashContainer?.get_hover?.() || this._draggingItem || this._blockAutoHide || this._isMenuOpen()) {
         return GLib.SOURCE_CONTINUE;
       }
-      
+
       this.hide(true);
       this._autohideTimeoutId = 0;
       return GLib.SOURCE_REMOVE;
@@ -640,7 +679,7 @@ export class AuroraDash extends Dash {
       && this.translation_y === 0
       && this.scale_x === 1
       && this.scale_y === 1
-      && this.opacity === 255;
+      && this.opacity === FULL_OPACITY;
   }
 
   private _isFullyHidden(): boolean {
@@ -689,7 +728,7 @@ export class AuroraDash extends Dash {
       height: size.height + p * 2,
     };
 
-    if (!boundsEqual(this._targetBox, padded)) {
+    if (!AuroraDash._boundsEqual(this._targetBox, padded)) {
       this._targetBox = padded;
       this._targetBoxListener?.(this._targetBox);
     }
@@ -725,7 +764,200 @@ export class AuroraDash extends Dash {
     });
   }
 
-  private _clearTimeout(prop: '_autohideTimeoutId' | '_delayEnsureAutoHideId' | '_blockAutoHideDelayId' | '_workAreaUpdateId'): void {
+  /**
+   * Install a drag monitor and pre-expand the container for one drag session.
+   *
+   * ## Stable slot calculation
+   * We track `_dndBoxOriginX` = the stage-X of `_box`. While no placeholder
+   * exists the origin is refreshed every dragMotion frame (the box is stable).
+   * The origin `_dndBoxOriginX` is frozen at the pre-drag value of `_box`'s
+   * stage-X while a placeholder exists, and refreshed per-frame when the box
+   * is stable (no placeholder). This works because `handleDragOver` always
+   * subtracts `placeholder.width` from `boxWidth`, making:
+   *   boxWidth_adj = _box.width − placeholder.width = origBoxW
+   * so `pos = floor((event.x − _dndBoxOriginX) × N / origBoxW)` is identical
+   * in all frames — no analytical correction is needed.
+   *
+   * On first placeholder insertion we cancel its fade-in animation immediately
+   * so the layout settles in a single frame.
+   */
+  private _setupDnd(_source: any): void {
+    if (this._dndMonitor) return;
+
+    this._savedDndSource = null;
+    this._dndDropHandled = false;
+
+    // Capture initial origin and pre-expand the container.
+    const box = (this as any)._box;
+    this._dndBoxOriginX = (box?.get_transformed_position?.() ?? [0])[0];
+    this._preExpandContainer();
+    this._patchClearDragPlaceholder();
+
+    this._dndMonitor = {
+      dragMotion: (event: any) => this._dndDragMotion(event),
+      dragDrop: (event: any) => this._dndDragDrop(event),
+    };
+    DND.addDragMonitor(this._dndMonitor);
+  }
+
+  private _teardownDnd(): void {
+    if (this._dndMonitor) {
+      DND.removeDragMonitor(this._dndMonitor);
+      this._dndMonitor = null;
+    }
+    this._cancelClearPlaceholderTimer();
+    this._restoreClearDragPlaceholder();
+    this._savedDndSource = null;
+    this._dndDropHandled = false;
+    if (this._workArea) this.applyWorkArea(this._workArea);
+  }
+
+  private _dndDragMotion(event: any): any {
+    if (this._isDestroyed) return DND.DragMotionResult.CONTINUE;
+
+    const container = this._container;
+    const box = (this as any)._box;
+    if (!container || !box) return DND.DragMotionResult.CONTINUE;
+
+    // Bounds check against the pre-expanded, position-stable container.
+    const [ok, contLocalX, contLocalY] = (container as any).transform_stage_point(event.x, event.y);
+    if (!ok) return DND.DragMotionResult.CONTINUE;
+
+    const [contW, contH] = (container as any).get_size();
+    if (contLocalX < 0 || contLocalX > contW || contLocalY < 0 || contLocalY > contH) {
+      this._scheduleClearPlaceholder();
+      return DND.DragMotionResult.CONTINUE;
+    }
+
+    this._cancelClearPlaceholderTimer();
+
+    // Refresh _box origin only while no placeholder exists (box is stable).
+    // While a placeholder is present, `handleDragOver` self-normalizes:
+    // boxWidth_adj = _box.width − placeholder.width = origBoxW, so the frozen
+    // origin keeps pos consistent across all frames without any correction.
+    const dashAny = this as any;
+    if (!dashAny._dragPlaceholder) {
+      this._dndBoxOriginX = (box.get_transformed_position?.() ?? [0])[0];
+    }
+
+    const hadPlaceholder = dashAny._dragPlaceholder !== null;
+    const localX = event.x - this._dndBoxOriginX;
+
+    const result =
+      (Dash.prototype as any).handleDragOver?.call(this, event.source, event.dragActor, localX, contLocalY, 0) ??
+      DND.DragMotionResult.CONTINUE;
+
+    // On first insertion: cancel fade-in animation so the layout settles
+    // immediately in a single frame rather than over ~200 ms.
+    if (!hadPlaceholder && dashAny._dragPlaceholder?.child) {
+      dashAny._dragPlaceholder.child.remove_all_transitions?.();
+      dashAny._dragPlaceholder.child.set_width(dashAny.iconSize);
+    }
+
+    if (result === DND.DragMotionResult.MOVE_DROP) {
+      this._savedDndSource = event.source;
+    }
+
+    return result;
+  }
+
+  /**
+   * On drop: patch targetActor._delegate so dnd.js actor-traversal reaches
+   * our acceptDrop. Returning CONTINUE lets dnd.js perform its own cleanup
+   * (removes drag actor, emits drag-end, restores cursor).
+   */
+  private _dndDragDrop(event: any): any {
+    if (this._isDestroyed) return DND.DragDropResult.CONTINUE;
+
+    const container = this._container;
+    if (!container || !this._savedDndSource) return DND.DragDropResult.CONTINUE;
+
+    const [cx, cy] = event.clutterEvent?.get_coords?.() ?? [0, 0];
+    const [ok, localX, localY] = (container as any).transform_stage_point(cx, cy);
+    if (!ok) return DND.DragDropResult.CONTINUE;
+
+    const [cW, cH] = (container as any).get_size();
+    if (localX < 0 || localX > cW || localY < 0 || localY > cH) return DND.DragDropResult.CONTINUE;
+
+    const targetActor = event.targetActor;
+    if (targetActor) {
+      const origDelegate = targetActor._delegate;
+      targetActor._delegate = {
+        acceptDrop: (source: any, actor: any, x: number, y: number, time: number) => {
+          targetActor._delegate = origDelegate;
+          const accepted = (Dash.prototype as any).acceptDrop?.call(this, source, actor, x, y, time) ?? false;
+          if (accepted) this._dndDropHandled = true;
+          return accepted;
+        },
+      };
+    }
+
+    return DND.DragDropResult.CONTINUE;
+  }
+
+  /** Pre-expand the container by one icon-slot width before the drag monitor activates. */
+  private _preExpandContainer(): void {
+    if (!this._container || !this._workArea) return;
+
+    const dashAny = this as any;
+    const firstChild = (dashAny._box?.get_children?.() ?? [])[0];
+    const slotWidth =
+      Math.ceil((firstChild?.get_size?.() ?? [0, 0])[0]) ||
+      (dashAny.iconSize ?? 48) + 24;
+
+    const wa = this._workArea;
+    const [, prefW] = this.get_preferred_width(wa.width);
+    const curW = Math.min(Math.max(prefW, 0), wa.width);
+    const expandedW = Math.min(curW + slotWidth, wa.width);
+    const expandedX = wa.x + Math.round((wa.width - expandedW) / 2);
+    const [, prefH] = this.get_preferred_height(expandedW);
+    const expandedH = Math.min(Math.max(prefH, 0), wa.height);
+    const marginBottom = this._getMarginBottom();
+    const expandedY = Math.max(wa.y, wa.y + wa.height - expandedH - marginBottom);
+
+    this._container.set_size(expandedW, expandedH);
+    this._container.set_position(expandedX, expandedY);
+  }
+
+  /**
+   * Replace `_clearDragPlaceholder` on the instance to destroy the placeholder
+   * immediately (no animate-out). This keeps `_animatingPlaceholdersCount` at 0
+   * so `handleDragOver` never enters its ~200 ms locked state.
+   */
+  private _patchClearDragPlaceholder(): void {
+    const dashAny = this as any;
+    dashAny._clearDragPlaceholder = () => {
+      if (dashAny._dragPlaceholder) {
+        dashAny._dragPlaceholder.remove_all_transitions?.();
+        dashAny._dragPlaceholder.child?.remove_all_transitions?.();
+        dashAny._dragPlaceholder.destroy();
+        dashAny._dragPlaceholder = null;
+      }
+      dashAny._dragPlaceholderPos = -1;
+    };
+  }
+
+  private _restoreClearDragPlaceholder(): void {
+    delete (this as any)._clearDragPlaceholder;
+  }
+
+  private _scheduleClearPlaceholder(): void {
+    if (this._clearPlaceholderTimerId) return;
+    this._clearPlaceholderTimerId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, CLEAR_PLACEHOLDER_DELAY, () => {
+      this._clearPlaceholderTimerId = 0;
+      if (!this._isDestroyed) (this as any)._clearDragPlaceholder?.();
+      return GLib.SOURCE_REMOVE;
+    });
+  }
+
+  private _cancelClearPlaceholderTimer(): void {
+    if (this._clearPlaceholderTimerId) {
+      GLib.source_remove(this._clearPlaceholderTimerId);
+      this._clearPlaceholderTimerId = 0;
+    }
+  }
+
+  private _clearTimeout(prop: TimeoutProp): void {
     if (this[prop]) {
       GLib.source_remove(this[prop]);
       this[prop] = 0;
@@ -738,10 +970,10 @@ export class AuroraDash extends Dash {
     this._clearTimeout('_blockAutoHideDelayId');
     this._clearTimeout('_workAreaUpdateId');
   }
-}
 
-function boundsEqual(a: DashBounds | null, b: DashBounds | null): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+  private static _boundsEqual(a: DashBounds | null, b: DashBounds | null): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+  }
 }


### PR DESCRIPTION
This pull request refactors the `AuroraDash` class in `src/shared/ui/dash.ts` to simplify drag-and-drop handling, improve code clarity, and enhance maintainability. The changes remove custom drag state tracking in favor of overriding parent class methods, consolidate constants, and make utility functions static. The refactor also clarifies the use of opacity and pivot values by introducing named constants, and improves the handling of timeouts and bounds comparison.

**Drag-and-drop and event handling simplification:**
- Removed custom drag state tracking (`_draggingItem`) and related signal connections, instead overriding parent `Dash` drag-and-drop methods to guard against actions on destroyed objects and to ensure proper event handling. This reduces complexity and makes the code more robust against GNOME Shell changes. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L56-L60) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L72-L78) [[3]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L123-L127) [[4]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L343-R372)
- Added an override for `handleDragOver` to update the work area during drag operations, ensuring UI stays responsive and up-to-date.

**Constants and code clarity:**
- Introduced named constants such as `FULL_OPACITY` and `PIVOT_CENTER_BOTTOM` to replace magic numbers for opacity and pivot points, improving readability and maintainability. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9R22-R30) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L240-R228) [[3]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L301-R289) [[4]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L315-R303) [[5]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L332-R320) [[6]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L643-R629)

**Timeout and utility improvements:**
- Added a `TimeoutProp` type alias and updated the `_clearTimeout` method to use it, streamlining timeout management. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9R22-R30) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L728-R714)
- Made the bounds comparison function (`_boundsEqual`) a static private method of `AuroraDash` instead of a standalone function, clarifying its scope and usage. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L692-R678) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L741-R733)

**Minor cleanups:**
- Removed unused or obsolete properties and methods, such as `_cycleState`, further simplifying the class. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L56-L60) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L139)
- Updated comments and docstrings to reflect the new structure and clarify intent. [[1]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9L609-R602) [[2]](diffhunk://#diff-87ed0b3f9b629b68587f8b07d6c9072e32ff129e8dbe8b292501226606694fc9R470)

**Robustness and bug fixes:**
- Ensured that all overridden methods check for the destroyed state before proceeding, preventing errors from signals firing after object disposal.

These changes collectively make the `AuroraDash` implementation cleaner, safer, and easier to maintain.