### PR TITLE
fix(dock): Fix drag'n drop hover background in dock

### DIFF
--- a/scripts/run-gnome-shell.sh
+++ b/scripts/run-gnome-shell.sh
@@ -5,15 +5,20 @@ set -e
 TOOLBOX="${1:-gnome-shell-devel}"
 
 SHELL_ENV=(
+  SHELL_DEBUG=all
   XDG_CURRENT_DESKTOP=GNOME
   XDG_SESSION_TYPE=wayland
   GSETTINGS_SCHEMA_DIR=/usr/share/glib-2.0/schemas
 )
-SHELL_ARGS=( --wayland --devkit )
+SHELL_ARGS=( --wayland --devkit --debug-control )
 
 if [[ ! :$XDG_DATA_DIRS: =~ :/usr/share/?: ]]
 then
   SHELL_ENV+=(XDG_DATA_DIRS=$XDG_DATA_DIRS:/usr/share/)
+fi
+
+if [[ -n "$AURORA_TRAY_DEBUG" ]]; then
+  SHELL_ENV+=(AURORA_TRAY_DEBUG=$AURORA_TRAY_DEBUG)
 fi
 
 echo "Running GNOME Shell in toolbox '$TOOLBOX'..."

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -754,6 +754,7 @@ export class AuroraDash extends Dash {
 
           const appIcon = target?.child?._delegate;
           if (appIcon?.app) {
+            target.add_style_class_name?.('aurora-drag-hover');
             const isRelevant = (w: any) => this._isWindowRelevant(w);
             this._springLoadTimerId = GLib.timeout_add(
               GLib.PRIORITY_DEFAULT,
@@ -786,6 +787,7 @@ export class AuroraDash extends Dash {
   }
 
   private _clearSpringLoad(): void {
+    this._springLoadTarget?.remove_style_class_name?.('aurora-drag-hover');
     this._clearTimeout('_springLoadTimerId');
     this._springLoadTarget = null;
   }

--- a/src/styles/_dash.scss
+++ b/src/styles/_dash.scss
@@ -113,3 +113,7 @@
 .dash-label.flush-mode {
   -y-offset: 20px !important;
 }
+
+#dash .dash-item-container.aurora-drag-hover .overview-icon {
+  background-color: vars.$aurora-dash-hover-bg;
+}


### PR DESCRIPTION
This pull request introduces improvements to the GNOME Shell development environment setup and enhances the drag-and-drop user experience in the Aurora Dash UI. The most notable changes are grouped below:

**Development Environment Enhancements:**

* Added `SHELL_DEBUG=all` and support for the `AURORA_TRAY_DEBUG` environment variable to the GNOME Shell run script, enabling more robust debugging. Also, appended `--debug-control` to the shell arguments for increased runtime diagnostics (`scripts/run-gnome-shell.sh`).

**UI/UX Improvements for Drag-and-Drop:**

* When dragging over a dash item, the `aurora-drag-hover` style class is now added to visually indicate the hover state (`src/shared/ui/dash.ts`).
* The `aurora-drag-hover` style class is removed when the drag operation ends or is cancelled, ensuring proper cleanup of visual feedback (`src/shared/ui/dash.ts`).
* Introduced a new SCSS rule to style dash items with the `aurora-drag-hover` class, applying a background color defined by `$aurora-dash-hover-bg` for clearer drag-over feedback (`src/styles/_dash.scss`).