### PR TITLE
feat: add automated backport request process and Shexli review scan

### DIFF
--- a/.github/workflows/gnome-backport.yml
+++ b/.github/workflows/gnome-backport.yml
@@ -1,0 +1,128 @@
+name: GNOME Backport
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, closed]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Create GNOME maintenance PR
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed' || github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create or update backport PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          LABEL=$(jq -r '
+            .pull_request.labels[]
+            | select(.name | test("^GNOME [0-9]+$"))
+            | .name
+          ' "$GITHUB_EVENT_PATH" | head -n1)
+
+          if [ -z "$LABEL" ]; then
+            echo "No GNOME release label found; skipping."
+            exit 0
+          fi
+
+          MAJOR="${LABEL#GNOME }"
+          export MAJOR
+          BASE_BRANCH="release/v${MAJOR}.x"
+          BACKPORT_BRANCH="backport/pr-${PR_NUMBER}-gnome-${MAJOR}"
+          ERROR_BODY="/tmp/backport-error.md"
+
+          on_error() {
+            git cherry-pick --abort >/dev/null 2>&1 || true
+            {
+              echo "Backport to \`${BASE_BRANCH}\` failed."
+              echo ""
+              echo "Label: \`${LABEL}\`"
+              echo "Branch: \`${BACKPORT_BRANCH}\`"
+              echo ""
+              echo "Please create the backport manually or resolve the conflict locally."
+            } > "$ERROR_BODY"
+            gh pr comment "$PR_NUMBER" --body-file "$ERROR_BODY" || true
+          }
+          trap on_error ERR
+
+          git fetch origin "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+          git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}/head"
+          git checkout -B "$BACKPORT_BRANCH" "origin/${BASE_BRANCH}"
+
+          NEXT_VERSION=$(node -e '
+            const fs = require("fs");
+            const major = process.env.MAJOR;
+            const metadata = JSON.parse(fs.readFileSync("metadata.json", "utf8"));
+            const version = metadata["version-name"];
+            const match = new RegExp(`^${major}\\.([0-9]+)$`).exec(version);
+            if (!match) {
+              throw new Error(`metadata.json version-name must be ${major}.x on release branch, got ${version}`);
+            }
+            process.stdout.write(`${major}.${Number(match[1]) + 1}`);
+          ')
+          export NEXT_VERSION
+
+          COMMITS=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
+          for SHA in $COMMITS; do
+            git cherry-pick -x "$SHA"
+          done
+
+          node -e '
+            const fs = require("fs");
+            const metadata = JSON.parse(fs.readFileSync("metadata.json", "utf8"));
+            metadata["version-name"] = process.env.NEXT_VERSION;
+            fs.writeFileSync("metadata.json", `${JSON.stringify(metadata, null, 4)}\n`);
+          '
+          git add metadata.json
+          if git diff --cached --quiet; then
+            git commit --allow-empty -m "Bump version to ${NEXT_VERSION}"
+          else
+            git commit -m "Bump version to ${NEXT_VERSION}"
+          fi
+
+          git push --force-with-lease origin "$BACKPORT_BRANCH"
+
+          EXISTING_PR=$(gh pr list \
+            --head "$BACKPORT_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          BODY=$(mktemp)
+          {
+            echo "Backport of #${PR_NUMBER} to \`${BASE_BRANCH}\`."
+            echo ""
+            echo "This branch also bumps \`metadata.json\` to \`${NEXT_VERSION}\`."
+          } > "$BODY"
+
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --title "Backport #${PR_NUMBER} to GNOME ${MAJOR}" \
+              --body-file "$BODY"
+            echo "Updated backport PR #${EXISTING_PR}."
+          else
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$BACKPORT_BRANCH" \
+              --title "Backport #${PR_NUMBER} to GNOME ${MAJOR}" \
+              --body-file "$BODY"
+          fi

--- a/.github/workflows/post-hygiene.yml
+++ b/.github/workflows/post-hygiene.yml
@@ -1,0 +1,154 @@
+name: Post Hygiene
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  schedule:
+    - cron: '17 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  validate-post:
+    name: Validate duplicate/stale post
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    steps:
+      - name: Check duplicate title and stale state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- aurora-post-hygiene -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const item = context.payload.issue ?? context.payload.pull_request;
+            const number = item.number;
+            const title = item.title ?? '';
+            const labels = (item.labels ?? []).map((label) => label.name.toLowerCase());
+            const normalizedTitle = title
+              .toLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim()
+              .replace(/\s+/g, ' ');
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+            const openItems = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const duplicates = openItems.filter((candidate) => {
+              if (candidate.number === number) return false;
+              const candidateTitle = (candidate.title ?? '')
+                .toLowerCase()
+                .replace(/[^\p{L}\p{N}]+/gu, ' ')
+                .trim()
+                .replace(/\s+/g, ' ');
+              return candidateTitle === normalizedTitle;
+            });
+
+            const problems = [];
+            if (labels.includes('stale')) {
+              problems.push('This post is labeled `stale`; remove the label or close/triage it before continuing.');
+            }
+
+            if (duplicates.length > 0) {
+              await ensureLabel('duplicate', 'cfd3d7', 'Potential duplicate issue or pull request');
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: ['duplicate'],
+              });
+              const duplicateLinks = duplicates
+                .map((candidate) => `- #${candidate.number}: ${candidate.title}`)
+                .join('\n');
+              problems.push(`Possible duplicate title detected:\n${duplicateLinks}`);
+            } else if (labels.includes('duplicate')) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: 'duplicate',
+              }).catch((error) => {
+                if (error.status !== 404) throw error;
+              });
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: number,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) => comment.body?.startsWith(marker));
+
+            if (problems.length > 0) {
+              const body = `${marker}\n${problems.map((problem) => `- ${problem}`).join('\n')}`;
+              if (previous) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: previous.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  body,
+                });
+              }
+              core.setFailed(problems.join('\n'));
+            } else if (previous) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+              });
+            }
+
+  mark-stale:
+    name: Mark and close stale posts
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Mark inactive posts as stale and close stale issues
+        uses: actions/stale@v10
+        with:
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-issue-stale: 45
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-close: -1
+          days-before-pr-close: -1
+          close-issue-label: closed-as-stale
+          close-issue-reason: not_planned
+          remove-stale-when-updated: true
+          operations-per-run: 100
+          stale-issue-message: |
+            This issue has been marked as stale because it has not had recent activity. Add a comment or remove the `stale` label if it is still relevant.
+          close-issue-message: |
+            This issue has been closed because it stayed stale without further activity. Reopen it or file a new issue if it is still relevant.
+          stale-pr-message: |
+            This pull request has been marked as stale because it has not had recent activity. Update it, add a comment, or remove the `stale` label if it should stay active.
+          exempt-issue-labels: pinned,security,release-blocker
+          exempt-pr-labels: pinned,security,release-blocker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,17 +26,18 @@ Do not leave a task incomplete if either command reports errors or failures.
 ## Commands
 
 - **Install deps:** `just deps` — runs `yarn install`; use once or when updating packages
-- **Build:** `just build` — compiles TypeScript and SCSS, copies metadata/schemas, compiles `.mo` files
+- **Build:** `just build` — compiles TypeScript and SCSS, copies metadata/schemas, and compiles `.mo` files
 - **Package:** `just package` — packs the extension as a `.zip` in `dist/target/` (depends on `build`)
 - **Install:** `just install` — installs the already-packaged `.zip` to GNOME Shell (requires `just package` first)
 - **Full install:** `just full-install` — packages + installs in one step
 - **All:** `just all` — clean + full-install
 - **Uninstall:** `just uninstall` — disables and removes the extension
-- **Run (host):** `just run` — launches a devkit GNOME Shell session (headless, Wayland)
-- **Run (toolbox):** `just toolbox run` — same as above, but inside the Fedora toolbox
+- **Run (host):** `just run` — packages, installs, then launches a devkit GNOME Shell session
+- **Run (toolbox):** `just toolbox run` — packages/installs on the host, then runs GNOME Shell inside the Fedora toolbox
 - **Create toolbox:** `just toolbox create` — create the `aurora-shell-devel` Fedora toolbox
 - **Remove toolbox:** `just toolbox remove` — delete the toolbox
 - **Validate:** `just validate` — runs tsc, ESLint, Prettier check, and Stylelint
+- **Shexli:** `just shexli` — packages the extension and runs the extensions.gnome.org static analyzer on the generated ZIP
 - **Lint:** `just lint` — runs ESLint only
 - **Watch SCSS:** `just watch` — watches `src/styles/` and recompiles on change
 - **View logs:** `just logs` — shows recent `aurora` entries from the current boot journal
@@ -52,7 +53,7 @@ Do not leave a task incomplete if either command reports errors or failures.
 
 ### Translation commands
 
-- **Regenerate POT template:** `just pot` — builds then scans compiled JS (`dist/`) and writes the `.pot` into `dist/` (a build artifact, **not** committed — avoids `POT-Creation-Date` churn). Run this whenever translatable strings are added or removed.
+- **Regenerate POT template:** `just pot` — builds, then scans compiled JS (`dist/`) and writes the `.pot` into `dist/` (a build artifact, **not** committed — avoids `POT-Creation-Date` churn). Run this whenever translatable strings are added or removed.
 - **Merge new strings into .po files:** `just update-po` — depends on `pot`; regenerates the template into `dist/` then runs `msgmerge` on every `data/po/*.po` against it. The hand-translated `data/po/*.po` files are the committed source of truth.
 - **Compile .mo binaries:** `just compile-mo` — compiles each `po/*.po` into `dist/locale/<lang>/LC_MESSAGES/*.mo`. Called automatically by `just build`.
 
@@ -68,7 +69,8 @@ Do not leave a task incomplete if either command reports errors or failures.
     - `context.ts` — `ExtensionContext` interface and implementation
     - `logger.ts` — Abstracted logging
     - `settings.ts` — `SettingsManager` abstraction for GSettings
-  - `modules/` — one **folder** per feature module, named after the module (e.g., `dock/dock.ts`); the main entry file shares the folder name
+  - `modules/` — feature modules registered by `registry.ts`
+    - regular modules use one **folder** per feature module, named after the module (e.g., `dock/dock.ts`); the main entry file shares the folder name
   - `dev/` — developer-only tooling (e.g., `devTool.ts`), gated behind the `AURORA_DEVTOOLS=1` env var. **Not** a feature module: it is not in the registry, prefs, or gschema, and is instantiated directly by `extension.ts`
   - `shared/` — shared utilities used across modules (e.g., `quickSettings.ts`)
   - `styles/` — SCSS stylesheets (compiled to light + dark CSS)
@@ -98,7 +100,7 @@ Do not leave a task incomplete if either command reports errors or failures.
 
 ## Adding a Module
 
-1. Create `src/modules/myModule/myModule.ts` with a `Module` subclass **and** a co-located `definition` export. Every module **must** live in its own folder named after the module (e.g., `dock/dock.ts`, `panel/panel.ts`):
+1. Create `src/modules/myModule/myModule.ts` with a `Module` subclass **and** a co-located `definition` export. Regular modules **must** live in their own folder named after the module (e.g., `dock/dock.ts`, `panel/panel.ts`).
 
 ```typescript
 import { gettext as _ } from 'gettext';
@@ -161,7 +163,7 @@ return [/* …, */ myModule];
 </key>
 ```
 
-`tests/unit/registry.test.ts` enforces that step 2, step 3, and step 4 stay in parity — including that every module's `section` is a known section id and matches between the registry and `prefsMetadata.ts`. A half-finished addition will fail CI.
+`tests/unit/registry.test.ts` enforces that steps 2, 3, and 4 stay in parity — including that every module's `section` is a known section id and matches between the registry and `prefsMetadata.ts`. A half-finished addition will fail CI.
 
 ### Prefs sections
 
@@ -190,6 +192,19 @@ Per the GNOME review guidelines, clipboard-related keyboard shortcuts must not s
 - Constants: `UPPER_CASE`
 - Keep `enable()` and `disable()` symmetric.
 - Read settings through `this.context.settings`. Importing `Main`/`Shell`/`St` directly is fine — keep heavy algorithms in shell-free pure files so they stay unit-testable.
+
+## Human Review Quality Bar
+
+Avoid code that only looks plausible. A human reviewer should be able to read a change and see a real contract, not a guess.
+
+- Do not add optional calls such as `object?.method?.(...)` unless that method is a real, documented API or the local type intentionally models it. Never use patterns like `this.disconnectObject?.(this)` on objects that do not own that signal connection contract.
+- Do not ship fake behavior. If a UI label, schema description, README entry, or module subtitle says a feature is wired to NetworkManager, ModemManager, UPower, sensors, widgets, or GNOME internals, the code must actually call the relevant API or clearly describe itself as a fallback.
+- Keep runtime capability checks honest. Hardware-specific modules must detect missing services/devices at runtime and stay inactive or degrade explicitly.
+- Do not scatter `as unknown as ...` casts through feature modules. If GObject construction or Shell internals require a cast, isolate it in a small shared helper/factory with a clear name.
+- Do not leave placeholder helpers, legacy duplicates, or unused compatibility functions after a refactor. Remove dead code instead of keeping it “just in case”.
+- Keep strings and metadata truthful and synchronized across module `definition`, `src/prefsMetadata.ts`, schema XML, README/architecture docs, and `.po` files when strings change.
+- Search for obvious generated-code artifacts before finishing: broken joined words in docs, stale project names, obsolete env vars, and UI descriptions that exceed what is implemented.
+- Prefer explicit D-Bus/property handling over no-op calls that only log success. If a feature cannot be safely implemented yet, make the limitation visible in the title/subtitle/docs rather than implying it works.
 
 ## Logging Style
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# Aurora Shell Architecture
+
+Aurora Shell is a modular GNOME Shell extension. Regular features live as registry modules: each
+module exports a colocated `definition` object and is instantiated by `src/extension.ts` through
+`src/registry.ts`.
+
+## Overview
+
+```mermaid
+flowchart TD
+  Shell[GNOME Shell] --> Extension[src/extension.ts]
+  Extension --> Context[src/core/context.ts]
+  Extension --> Registry[src/registry.ts]
+  Registry --> Modules[src/modules/*]
+  Modules --> Shared[src/shared/*]
+  Modules --> Core[src/core/*]
+  Prefs[src/prefs.ts] --> PrefsMetadata[src/prefsMetadata.ts]
+  PrefsMetadata -. mirrors .-> Registry
+  Schema[data/schemas/*.xml] -. validates settings .-> Registry
+  Tests[tests/unit + tests/shell] --> Registry
+  Tests --> Modules
+```
+
+## Source Layout
+
+```text
+src/
+  core/                  Extension context, settings, and logging
+  dev/                   Developer-only tools
+  modules/               Feature modules registered in the extension
+    ...                  One folder per regular Aurora module
+  shared/                Utilities shared by modules
+  styles/                SCSS partials compiled into Shell stylesheets
+```
+
+## Runtime Lifecycle
+
+```mermaid
+sequenceDiagram
+  participant Shell as GNOME Shell
+  participant Ext as extension.ts
+  participant Ctx as ExtensionContext
+  participant Reg as registry.ts
+  participant Mod as Module
+  participant Settings as GSettings
+
+  Shell->>Ext: enable()
+  Ext->>Settings: getSettings()
+  Ext->>Ctx: create context
+  Ext->>Reg: getModuleRegistry()
+  Reg-->>Ext: ModuleDefinition[]
+  loop enabled module setting
+    Ext->>Settings: get_boolean(def.settingsKey)
+    Ext->>Mod: def.factory(context)
+    Ext->>Mod: enable()
+  end
+  Ext->>Settings: connect changed::module-*
+  Settings-->>Ext: setting changed
+  Ext->>Mod: enable() or disable()
+  Shell->>Ext: disable()
+  Ext->>Settings: disconnectObject(this)
+  Ext->>Mod: disable()
+```
+
+## Module Contract
+
+```mermaid
+classDiagram
+  class Module {
+    <<abstract>>
+    #context ExtensionContext
+    +enable() void
+    +disable() void
+  }
+
+  class ModuleDefinition {
+    +key string
+    +settingsKey string
+    +section string
+    +title string
+    +subtitle string
+    +options ModuleOption[]
+    +factory(context) Module
+  }
+
+  class ExtensionContext {
+    +uuid string
+    +path string
+    +settings SettingsManager
+  }
+
+  ModuleDefinition --> Module : creates
+  Module --> ExtensionContext : uses
+```
+
+Each module owns its runtime behavior and cleanup. `enable()` and `disable()` must stay symmetric:
+actors, signal handlers, timeouts, D-Bus watches, and injected Shell UI must be removed by the same
+module that created them.
+
+## Registry And Preferences
+
+Every registry module must stay in sync across:
+
+- `src/registry.ts`
+- `src/prefsMetadata.ts`
+- `data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml`
+
+```mermaid
+flowchart LR
+  Definition[Module definition] --> Registry[src/registry.ts]
+  Definition --> PrefsMirror[src/prefsMetadata.ts]
+  Definition --> SchemaKey[GSettings module-* key]
+
+  Registry --> Runtime[Runtime enable/disable]
+  PrefsMirror --> Preferences[Preferences UI]
+  SchemaKey --> Settings[GSettings storage]
+
+  UnitTests[registry.test.ts + schema.test.ts] --> Registry
+  UnitTests --> PrefsMirror
+  UnitTests --> SchemaKey
+```
+
+`tests/unit/registry.test.ts` and `tests/unit/schema.test.ts` enforce that parity. A module addition
+is incomplete until all three places are updated.
+
+## Test Boundaries
+
+```mermaid
+flowchart TD
+  Pure[Pure TypeScript logic] --> Unit[tests/unit/*.test.ts]
+  ShellGlue[St / Clutter / Main integration] --> ShellTests[tests/shell/aurora*.js]
+  Build[TypeScript + SCSS + schemas] --> Validate[just validate]
+  ShellTests --> Toolbox[just toolbox test-all]
+```
+
+Keep heavy algorithms outside Shell imports when practical. Shell-facing code is expected to import
+GNOME Shell internals directly and is verified through integration tests running a real headless
+Shell session.
+
+## Packaging
+
+```mermaid
+flowchart TD
+  Source[src/**/*.ts] --> Build[yarn build]
+  Styles[src/styles/*.scss] --> Build
+  Metadata[metadata.json] --> Package[gnome-extensions pack]
+  Schemas[data/schemas] --> Package
+  Icons[data/icons] --> Package
+  Translations[data/po] --> MO[compile .mo files]
+  Build --> Dist[dist/]
+  MO --> Dist
+  Dist --> Package
+  Package --> Zip[dist/target/*.shell-extension.zip]
+```
+
+`just package` builds TypeScript and SCSS into `dist/`, compiles schemas and translations, then
+packs the GNOME extension zip. Top-level generated directories imported at runtime must be listed as
+extra sources in the `justfile`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,15 @@ git cherry-pick <commit-sha>
 
 Maintainers decide which fixes are worth backporting. Not every fix needs to land in every maintenance branch.
 
+### Automated backports
+
+To request a maintenance backport, add a label such as `GNOME 50` to the original pull request.
+GitHub Actions creates or updates a separate backport PR targeting `release/v50.x`.
+
+The backport branch is rebuilt from the target release branch, cherry-picks the original PR commits,
+and adds a final version bump commit. For example, if `metadata.json` on `release/v50.x` says
+`50.7`, the generated backport PR bumps it to `50.8`.
+
 ### Release candidates
 
 Release candidates are published alongside GNOME Shell RCs. Tags follow the pattern `v50-rc1`, `v50-rc2`, etc. RC releases are automatically marked as **pre-releases** on GitHub.
@@ -182,12 +191,27 @@ The CI pipeline runs all tests and, if they pass, publishes the GitHub Release a
 - **Coverage:** `just coverage` — runs unit tests with coverage report
 - **Single integration test:** `just test <script>` — packages and runs one shell test headlessly
 - **All integration tests:** `just test-all` — packages and runs all shell tests on the host, printing a pass/fail summary
+- **Shexli review scan:** `just shexli` — packages the extension and runs the extensions.gnome.org static analyzer on the generated ZIP
 - **Watch SCSS:** `just watch` — watches `src/styles/` and recompiles on change
 - **View logs:** `just logs` — shows recent `aurora` entries from the current boot journal
 - **Clean:** `just clean` — removes `dist/`
 - **Deep clean:** `just distclean` — removes `dist/` and `node_modules/`
 
 *For a full test environment, create a Fedora toolbox via `just toolbox create` and run tests inside it using `just toolbox test-all` (preferred over `just test-all`).*
+
+## GNOME Extensions Review
+
+Aurora Shell can be checked locally with Shexli, the experimental static analyzer used by
+extensions.gnome.org:
+
+```bash
+just shexli
+```
+
+The recipe depends on `just package` and scans the generated
+`dist/target/aurora-shell@luminusos.github.io.shell-extension.zip`. Install Shexli with
+`python3 -m pip install --user shexli`, or install `uvx` and the recipe will run
+`uvx --from shexli shexli` automatically.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modular GNOME Shell extension that adds quality-of-life features missing in va
 
 > **Project goal:** Aurora Shell is a proving ground. Over time, the aim is for some of its
 > features to mature and make their way upstream into GNOME Shell itself. Modules here are
-> meant to be useful on their own today, and good candidates for upstream tomorrow.
+> meant to be useful on their own today and good candidates for upstream tomorrow.
 
 ## Modules
 
@@ -58,12 +58,12 @@ just install
 ## Testing
 
 ```bash
-# Run directly on the host (builds, installs, and launches GNOME Shell)
+# Build, install, and run directly on the host
 just run
 
-# Run inside a toolbox (useful when host lacks gnome-shell dev packages)
-just create-toolbox   # first time only
-just toolbox-run
+# Build, install, and run inside a toolbox
+just toolbox create   # first time only
+just toolbox run
 ```
 
 ## Contributing

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aurora-shell\n"
 "Report-Msgid-Bugs-To: https://github.com/luminusOS/aurora-shell/issues\n"
-"POT-Creation-Date: 2026-06-02 18:21-0300\n"
+"POT-Creation-Date: 2026-06-04 17:27-0300\n"
 "PO-Revision-Date: 2026-03-09 18:00-0300\n"
 "Last-Translator: Aurora Shell Contributors\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -56,52 +56,52 @@ msgstr ""
 msgid "Time to switch to dark theme (HH:MM)"
 msgstr ""
 
-#: dist/modules/bluetoothMenu/bluetoothMenu.js:92 dist/prefsMetadata.js:129
+#: dist/modules/bluetoothMenu/bluetoothMenu.js:93 dist/prefsMetadata.js:129
 msgid "Bluetooth Menu"
 msgstr ""
 
-#: dist/modules/bluetoothMenu/bluetoothMenu.js:93 dist/prefsMetadata.js:130
+#: dist/modules/bluetoothMenu/bluetoothMenu.js:94 dist/prefsMetadata.js:130
 msgid ""
 "Shows battery level and animated icons in the Bluetooth Quick Settings panel"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:146
-#: dist/modules/clipboardHistory/clipboardPanel.js:43 dist/prefsMetadata.js:267
+#: dist/modules/clipboardHistory/clipboardPanel.js:43 dist/prefsMetadata.js:261
 msgid "Clipboard History"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:147
-#: dist/prefsMetadata.js:268
+#: dist/prefsMetadata.js:262
 msgid "Searchable clipboard history with pinning and keyboard navigation"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:151
-#: dist/prefsMetadata.js:272
+#: dist/prefsMetadata.js:266
 msgid "Open Shortcut"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:152
-#: dist/prefsMetadata.js:273
+#: dist/prefsMetadata.js:267
 msgid "Keyboard shortcut to open the clipboard history panel"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:157
-#: dist/prefsMetadata.js:278
+#: dist/prefsMetadata.js:272
 msgid "Max History Items"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:158
-#: dist/prefsMetadata.js:279
+#: dist/prefsMetadata.js:273
 msgid "Number of non-pinned entries to retain"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:165
-#: dist/prefsMetadata.js:286
+#: dist/prefsMetadata.js:280
 msgid "Poll Interval (ms)"
 msgstr ""
 
 #: dist/modules/clipboardHistory/clipboardHistory.js:166
-#: dist/prefsMetadata.js:287
+#: dist/prefsMetadata.js:281
 msgid "How often to check the clipboard for changes"
 msgstr ""
 
@@ -289,59 +289,59 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:393 dist/prefsMetadata.js:136
+#: dist/modules/trayIcons/trayIcons.js:395 dist/prefsMetadata.js:210
 msgid "Tray Icons"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:394 dist/prefsMetadata.js:137
+#: dist/modules/trayIcons/trayIcons.js:396 dist/prefsMetadata.js:211
 msgid "System tray with SNI and background app icons"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:398 dist/prefsMetadata.js:141
+#: dist/modules/trayIcons/trayIcons.js:400 dist/prefsMetadata.js:215
 msgid "Visible Icon Limit"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:399 dist/prefsMetadata.js:142
+#: dist/modules/trayIcons/trayIcons.js:401 dist/prefsMetadata.js:216
 msgid "Maximum number of icons shown before the expand button appears"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:406 dist/prefsMetadata.js:149
+#: dist/modules/trayIcons/trayIcons.js:408 dist/prefsMetadata.js:223
 msgid "Icon Size"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:407 dist/prefsMetadata.js:150
+#: dist/modules/trayIcons/trayIcons.js:409 dist/prefsMetadata.js:224
 msgid "Tray icon size in pixels (14–24)"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:414 dist/prefsMetadata.js:157
+#: dist/modules/trayIcons/trayIcons.js:416 dist/prefsMetadata.js:231
 msgid "Attention Auto-Collapse (seconds)"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:415 dist/prefsMetadata.js:158
+#: dist/modules/trayIcons/trayIcons.js:417 dist/prefsMetadata.js:232
 msgid "Seconds before the tray collapses after a notification icon appears"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:422 dist/prefsMetadata.js:165
+#: dist/modules/trayIcons/trayIcons.js:424 dist/prefsMetadata.js:239
 msgid "Hide Background App When Tray Icon Present"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:423 dist/prefsMetadata.js:166
+#: dist/modules/trayIcons/trayIcons.js:425 dist/prefsMetadata.js:240
 msgid "Remove the background app icon when the same app has an SNI tray icon"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:428 dist/prefsMetadata.js:171
+#: dist/modules/trayIcons/trayIcons.js:430 dist/prefsMetadata.js:245
 msgid "Hide Background Apps from Quick Settings"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:429 dist/prefsMetadata.js:172
+#: dist/modules/trayIcons/trayIcons.js:431 dist/prefsMetadata.js:246
 msgid "Hide the Background Apps section from the Quick Settings dropdown"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:434 dist/prefsMetadata.js:177
+#: dist/modules/trayIcons/trayIcons.js:436 dist/prefsMetadata.js:251
 msgid "Recolor Symbolic Tray Icons"
 msgstr ""
 
-#: dist/modules/trayIcons/trayIcons.js:435 dist/prefsMetadata.js:178
+#: dist/modules/trayIcons/trayIcons.js:437 dist/prefsMetadata.js:252
 msgid "Automatically recolor monochrome SNI icons to match the panel theme"
 msgstr ""
 
@@ -419,7 +419,7 @@ msgid "Press a shortcut…"
 msgstr ""
 
 #: dist/prefsMetadata.js:6
-msgid "Dock &amp; Panel"
+msgid "Dock & Panel"
 msgstr ""
 
 #: dist/prefsMetadata.js:7
@@ -431,7 +431,7 @@ msgid "Behavior"
 msgstr ""
 
 #: dist/prefsMetadata.js:9
-msgid "Privacy &amp; Clipboard"
+msgid "Privacy & Clipboard"
 msgstr ""
 
 #~ msgid "Modules"

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -62,7 +62,7 @@
       <description>Keep the dock permanently visible and reserve screen space so windows never overlap it</description>
     </key>
     <key name="module-auto-theme-switcher" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Enable Auto Theme Switcher module</summary>
       <description>Automatically switches between light and dark theme based on configured times</description>
     </key>

--- a/justfile
+++ b/justfile
@@ -37,6 +37,22 @@ package: build
         --schema=schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
     echo "Packing Done!"
 
+shexli *args: package
+    #!/usr/bin/env bash
+    set -e
+    EXT="dist/target/{{ uuid }}.shell-extension.zip"
+
+    if command -v shexli >/dev/null 2>&1; then
+        shexli "$EXT" {{ args }}
+    elif command -v uvx >/dev/null 2>&1; then
+        uvx --from shexli shexli "$EXT" {{ args }}
+    else
+        echo "shexli is not installed."
+        echo "Install it with: python3 -m pip install --user shexli"
+        echo "Then run: just shexli"
+        exit 1
+    fi
+
 validate:
     yarn validate
     yarn lint
@@ -154,8 +170,11 @@ test-all: package
 run:
     #!/usr/bin/env bash
     set -e
-    env GSETTINGS_SCHEMA_DIR=/usr/share/glib-2.0/schemas \
-        XDG_CURRENT_DESKTOP=GNOME dbus-run-session gnome-shell --wayland --devkit
+    SHELL_ENV=(
+        GSETTINGS_SCHEMA_DIR=/usr/share/glib-2.0/schemas
+        XDG_CURRENT_DESKTOP=GNOME
+    )
+    env "${SHELL_ENV[@]}" dbus-run-session gnome-shell --wayland --devkit
 
 toolbox action *args:
     #!/usr/bin/env bash

--- a/scripts/run-gnome-shell.sh
+++ b/scripts/run-gnome-shell.sh
@@ -19,5 +19,5 @@ then
 fi
 
 echo "Running GNOME Shell in toolbox '$TOOLBOX'..."
-toolbox --container $TOOLBOX run \
+toolbox --container "$TOOLBOX" run \
   env "${SHELL_ENV[@]}" dbus-run-session gnome-shell "${SHELL_ARGS[@]}"

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -5,7 +5,9 @@ import type { SettingsManager } from './settings.ts';
  * Global signal bus for Aurora Shell modules
  */
 @GObject.registerClass({
-  Signals: { 'icons-woven': {} },
+  Signals: {
+    'icons-woven': {},
+  },
 })
 export class AuroraSignals extends GObject.Object {}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,12 +129,7 @@ export default class AuroraShellExtension extends Extension {
     }
   }
 
-  override disable(): void {
-    logger.debug('Disabling extension', { prefix: LOG_PREFIX });
-
-    this._settings?.disconnectObject(this);
-    this._disableDevTool();
-
+  private _disableAllModules(): void {
     for (const [name, module] of this._modules) {
       try {
         module.disable();
@@ -144,6 +139,14 @@ export default class AuroraShellExtension extends Extension {
     }
 
     this._modules.clear();
+  }
+
+  override disable(): void {
+    logger.debug('Disabling extension', { prefix: LOG_PREFIX });
+
+    if (this._settings) this._settings.disconnectObject(this);
+    this._disableDevTool();
+    this._disableAllModules();
     this._settings = null;
     this._context = null;
     cleanupIcons();

--- a/src/modules/bluetoothMenu/bluetoothMenu.ts
+++ b/src/modules/bluetoothMenu/bluetoothMenu.ts
@@ -94,6 +94,7 @@ export class BluetoothMenu extends Module {
     this._patchers.set(item, patcher);
 
     const id = item.connect('destroy', () => {
+      patcher.disable({ restoreOriginalChildren: false });
       this._patchers.delete(item);
       this._destroyIds.delete(item);
     });

--- a/src/modules/bluetoothMenu/deviceItem.ts
+++ b/src/modules/bluetoothMenu/deviceItem.ts
@@ -8,10 +8,13 @@ import Clutter from '@girs/clutter-18';
 import { logger } from '~/core/logger.ts';
 import { loadIcon } from '~/shared/icons.ts';
 
-const COLOR_DISCONNECTED = '#9a9a9a';
-const COLOR_CONNECTED = '#1c71d8';
-const COLOR_ANIMATING = '#3584e4';
 const LOG_PREFIX = 'BluetoothMenu';
+
+type DisableOptions = {
+  restoreOriginalChildren?: boolean;
+};
+
+type StateIconStatus = 'animating' | 'connected' | 'disconnected';
 
 export class BluetoothDeviceItemPatcher {
   private _item: any;
@@ -24,6 +27,7 @@ export class BluetoothDeviceItemPatcher {
   private _animationTimeoutId = 0;
   private _animationFrame = 1;
   private _animatingState: 'connecting' | 'disconnecting' | null = null;
+  private _disposed = true;
 
   constructor(item: any) {
     this._item = item;
@@ -31,6 +35,7 @@ export class BluetoothDeviceItemPatcher {
 
   enable(): void {
     const item = this._item;
+    this._disposed = false;
 
     // Override activate so clicking a device doesn't close the menu.
     // The parent PopupMenuBase listens to 'activate' and calls menu.close();
@@ -64,7 +69,7 @@ export class BluetoothDeviceItemPatcher {
 
     this._stateIcon = new St.Icon({
       icon_size: 16,
-      style_class: 'popup-menu-icon',
+      style_class: 'popup-menu-icon aurora-bt-state-icon',
       y_align: Clutter.ActorAlign.CENTER,
       x_expand: false,
     });
@@ -105,12 +110,16 @@ export class BluetoothDeviceItemPatcher {
   }
 
   private _scheduleUpdate(): void {
+    if (this._disposed) return;
+
     if (this._pendingUpdateId !== 0) {
       GLib.source_remove(this._pendingUpdateId);
       this._pendingUpdateId = 0;
     }
     this._pendingUpdateId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
       this._pendingUpdateId = 0;
+      if (this._disposed) return GLib.SOURCE_REMOVE;
+
       this._updateStateIcon();
       this._updateBatteryLabel();
       return GLib.SOURCE_REMOVE;
@@ -126,7 +135,7 @@ export class BluetoothDeviceItemPatcher {
   }
 
   private _updateStateIcon(): void {
-    if (!this._stateIcon) return;
+    if (this._disposed || !this._stateIcon) return;
 
     const connected: boolean = this._item._device.connected;
     const isWorking: boolean = this._item._spinner.visible;
@@ -138,11 +147,16 @@ export class BluetoothDeviceItemPatcher {
         this._animatingState = connected ? 'disconnecting' : 'connecting';
 
         this._animationTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+          if (this._disposed || !this._stateIcon) {
+            this._animationTimeoutId = 0;
+            return GLib.SOURCE_REMOVE;
+          }
+
           this._animationFrame = (this._animationFrame % 4) + 1;
-          this._stateIcon!.gicon = this._loadIcon(
+          this._stateIcon.gicon = this._loadIcon(
             `bbm-bluetooth-${this._animatingState}-${this._animationFrame}-symbolic`,
           );
-          this._stateIcon!.set_style(`color: ${COLOR_ANIMATING};`);
+          this._setStateIconStatus('animating');
           return GLib.SOURCE_CONTINUE;
         });
       }
@@ -150,7 +164,7 @@ export class BluetoothDeviceItemPatcher {
       this._stateIcon.gicon = this._loadIcon(
         `bbm-bluetooth-${state}-${this._animationFrame}-symbolic`,
       );
-      this._stateIcon.set_style(`color: ${COLOR_ANIMATING};`);
+      this._setStateIconStatus('animating');
     } else {
       this._animatingState = null;
       if (this._animationTimeoutId !== 0) {
@@ -159,16 +173,25 @@ export class BluetoothDeviceItemPatcher {
       }
       if (connected) {
         this._stateIcon.gicon = this._loadIcon('bbm-bluetooth-connected-symbolic');
-        this._stateIcon.set_style(`color: ${COLOR_CONNECTED};`);
+        this._setStateIconStatus('connected');
       } else {
         this._stateIcon.gicon = this._loadIcon('bbm-bluetooth-symbolic');
-        this._stateIcon.set_style(`color: ${COLOR_DISCONNECTED};`);
+        this._setStateIconStatus('disconnected');
       }
     }
   }
 
+  private _setStateIconStatus(status: StateIconStatus): void {
+    if (!this._stateIcon) return;
+
+    this._stateIcon.remove_style_class_name('aurora-bt-state-animating');
+    this._stateIcon.remove_style_class_name('aurora-bt-state-connected');
+    this._stateIcon.remove_style_class_name('aurora-bt-state-disconnected');
+    this._stateIcon.add_style_class_name(`aurora-bt-state-${status}`);
+  }
+
   private _updateBatteryLabel(): void {
-    if (!this._batteryLabel) return;
+    if (this._disposed || !this._batteryLabel) return;
     const connected: boolean = this._item._device.connected;
     const pct: number = this._item._device.battery_percentage;
     // Filter out 0% which is often a placeholder during initial connection
@@ -180,7 +203,10 @@ export class BluetoothDeviceItemPatcher {
     }
   }
 
-  disable(): void {
+  disable(options: DisableOptions = {}): void {
+    const restoreOriginalChildren = options.restoreOriginalChildren ?? true;
+    this._disposed = true;
+
     if (this._spinnerNotifyId) {
       this._item._spinner?.disconnect(this._spinnerNotifyId);
       this._spinnerNotifyId = 0;
@@ -204,22 +230,28 @@ export class BluetoothDeviceItemPatcher {
       this._animationTimeoutId = 0;
     }
 
-    this._stateIcon?.destroy();
+    if (restoreOriginalChildren) this._stateIcon?.destroy();
     this._stateIcon = null;
 
-    this._batteryLabel?.destroy();
+    if (restoreOriginalChildren) this._batteryLabel?.destroy();
     this._batteryLabel = null;
+
+    if (!restoreOriginalChildren) {
+      delete this._item.activate;
+      delete this._item.__auroraBtPatched;
+      return;
+    }
 
     // Re-insert removed children at their original positions.
     // Original layout: [ornament] [icon] [label] [subtitle] [spinner]
     if (this._item._icon) {
-      this._item.insert_child_at_index(this._item._icon, 1);
+      this._restoreChild(this._item._icon, 1);
     }
     if (this._item._subtitle) {
-      this._item.insert_child_at_index(this._item._subtitle, 3);
+      this._restoreChild(this._item._subtitle, 3);
     }
     if (this._item._spinner) {
-      this._item.insert_child_at_index(this._item._spinner, 4);
+      this._restoreChild(this._item._spinner, 4);
       this._item._spinner.opacity = 255;
       this._item._spinner.set_scale(1, 1);
     }
@@ -227,5 +259,11 @@ export class BluetoothDeviceItemPatcher {
     // Remove per-instance activate override so prototype method is restored.
     delete this._item.activate;
     delete this._item.__auroraBtPatched;
+  }
+
+  private _restoreChild(child: Clutter.Actor, index: number): void {
+    if (child.get_parent() !== this._item) {
+      this._item.insert_child_at_index(child, index);
+    }
   }
 }

--- a/src/modules/dock/intellihide.ts
+++ b/src/modules/dock/intellihide.ts
@@ -92,7 +92,6 @@ export class DockIntellihide extends GObject.Object {
     this._tracker = null;
     Main.keyboard.disconnectObject(this);
     Main.overview.disconnectObject(this);
-    this.disconnectObject?.(this);
   }
 
   private _checkOverlap(): void {

--- a/src/modules/trayIcons/backgroundAppsSource.ts
+++ b/src/modules/trayIcons/backgroundAppsSource.ts
@@ -104,7 +104,7 @@ export class BackgroundAppsSource {
     // Remove gone apps
     for (const [id] of this._knownIds) {
       if (!currentApps.has(id)) {
-        logger.log(`BG app removed from monitor: ${id}`, { prefix: LOG_PREFIX });
+        logger.debug(`BG app removed from monitor: ${id}`, { prefix: LOG_PREFIX });
         this._knownIds.delete(id);
         this._callbacks.onItemRemoved(`bg:${id}`);
       }
@@ -113,7 +113,7 @@ export class BackgroundAppsSource {
     // Add new apps
     for (const [appId, { app, message }] of currentApps) {
       if (!this._knownIds.has(appId)) {
-        logger.log(`BG app found in monitor: ${appId}`, { prefix: LOG_PREFIX });
+        logger.debug(`BG app found in monitor: ${appId}`, { prefix: LOG_PREFIX });
         const item = this._makeItem(appId, app, message);
         this._knownIds.set(appId, item);
         this._callbacks.onItemAdded(item, appId, app);

--- a/src/modules/trayIcons/sniHost.ts
+++ b/src/modules/trayIcons/sniHost.ts
@@ -122,7 +122,7 @@ export class SniHost {
       (proxy.get_cached_property('DesktopEntry')?.unpack() as string | undefined) ?? '';
 
     const menuPath = proxy.get_cached_property('Menu')?.unpack() as string | undefined;
-    logger.log(
+    logger.debug(
       `Registered item ${id}. Id=${sniId || '(none)'}. DesktopEntry=${desktopEntry || '(none)'}. Menu path: ${menuPath || 'none'}. Status: ${item.status}`,
       { prefix: LOG_PREFIX },
     );
@@ -203,7 +203,7 @@ export class SniHost {
     if (iconName) {
       const themedIcon = this._resolveThemedIcon(iconName, iconThemePath, itemId, reason);
       if (themedIcon) {
-        logger.log(
+        logger.debug(
           `SNI icon ${itemId} reason=${reason} source=theme-path name=${iconName} path=${iconThemePath}`,
           { prefix: LOG_PREFIX },
         );
@@ -215,7 +215,7 @@ export class SniHost {
     if (pixmaps) {
       const pb = this._extractPixbuf(pixmaps, itemId, reason);
       if (pb) {
-        logger.log(
+        logger.debug(
           `SNI icon ${itemId} reason=${reason} source=pixmap size=${pb.get_width()}x${pb.get_height()}`,
           { prefix: LOG_PREFIX },
         );
@@ -224,14 +224,14 @@ export class SniHost {
     }
 
     if (iconName) {
-      logger.log(
+      logger.debug(
         `SNI icon ${itemId} reason=${reason} source=icon-name name=${iconName} path=${iconThemePath || 'none'}`,
         { prefix: LOG_PREFIX },
       );
       return iconName;
     }
 
-    logger.log(`SNI icon ${itemId} reason=${reason} source=fallback`, { prefix: LOG_PREFIX });
+    logger.debug(`SNI icon ${itemId} reason=${reason} source=fallback`, { prefix: LOG_PREFIX });
     return 'image-missing-symbolic';
   }
 
@@ -340,7 +340,7 @@ export class SniHost {
       }
     }
 
-    logger.log(
+    logger.debug(
       `Recolored symbolic theme-path icon ${itemId} reason=${reason} scheme=${this._getColorScheme()} size=${w}x${h}`,
       { prefix: LOG_PREFIX },
     );
@@ -373,7 +373,7 @@ export class SniHost {
 
     if (!data || w <= 0 || h <= 0) return null;
     if (w < MIN_PIXMAP_SIZE || h < MIN_PIXMAP_SIZE) {
-      logger.log(`Ignoring tiny SNI pixmap ${itemId} reason=${reason} size=${w}x${h}`, {
+      logger.debug(`Ignoring tiny SNI pixmap ${itemId} reason=${reason} size=${w}x${h}`, {
         prefix: LOG_PREFIX,
       });
       return null;
@@ -395,7 +395,7 @@ export class SniHost {
     }
 
     if (symbolic) {
-      logger.log(
+      logger.debug(
         `Recolored symbolic SNI pixmap ${itemId} reason=${reason} scheme=${this._getColorScheme()} size=${w}x${h}`,
         { prefix: LOG_PREFIX },
       );

--- a/src/modules/trayIcons/sniWatcher.ts
+++ b/src/modules/trayIcons/sniWatcher.ts
@@ -104,7 +104,7 @@ export class SniWatcher {
       Gio.BusNameOwnerFlags.NONE,
       // GJS accepts plain functions here; types expect GObject.Closure
       (() => {
-        logger.info('Acquired org.kde.StatusNotifierWatcher', { prefix: LOG_PREFIX });
+        logger.debug('Acquired org.kde.StatusNotifierWatcher', { prefix: LOG_PREFIX });
         this._emitSignal('StatusNotifierHostRegistered', null);
       }) as unknown as never,
       (() => {
@@ -127,7 +127,7 @@ export class SniWatcher {
       // Bare object path (e.g., Steam): sender is the bus name
       busName = sender;
       objectPath = service;
-      logger.log(`SNI bare-path registration from ${sender}: ${service}`, {
+      logger.debug(`SNI bare-path registration from ${sender}: ${service}`, {
         prefix: LOG_PREFIX,
       });
     } else if (service.includes('/')) {

--- a/src/modules/trayIcons/trayContainer.ts
+++ b/src/modules/trayIcons/trayContainer.ts
@@ -163,6 +163,7 @@ export class TrayContainer extends PanelMenu.Button {
   declare private _attentionTimeoutSeconds: number;
   declare private _autoCollapseTimeoutId: number;
   declare private _debugPostAllocateId: number;
+  declare private _postAllocateRelayoutId: number;
   declare private _opacityTargets: WeakMap<TrayIconItem, number>;
   declare private _scrollTarget: number;
   declare private _smoothScrollAccumulator: number;
@@ -188,6 +189,7 @@ export class TrayContainer extends PanelMenu.Button {
     box.y1 = Math.round(box.y1);
     box.y2 = Math.round(box.y2);
     super.vfunc_allocate(box);
+    this._schedulePostAllocateRelayoutIfNeeded();
   }
 
   // @ts-expect-error Our _init signature differs from PanelMenu.Button._init overloads,
@@ -207,6 +209,7 @@ export class TrayContainer extends PanelMenu.Button {
     this._scrollTarget = 0;
     this._smoothScrollAccumulator = 0;
     this._debugPostAllocateId = 0;
+    this._postAllocateRelayoutId = 0;
 
     // Chevron button (collapse/expand toggle)
     this._chevronIcon = new St.Icon({
@@ -225,7 +228,7 @@ export class TrayContainer extends PanelMenu.Button {
     this._chevron.connect('clicked', () => {
       this._userInteracted = true;
       toggleCollapsed(this._state);
-      logger.log(`Chevron toggled collapsed=${this._state.collapsed}`, { prefix: LOG_PREFIX });
+      logger.debug(`Chevron toggled collapsed=${this._state.collapsed}`, { prefix: LOG_PREFIX });
       this._syncLayout(true);
     });
 
@@ -326,10 +329,12 @@ export class TrayContainer extends PanelMenu.Button {
     if (!centerBox) return fallbackWidth;
 
     if (this.get_text_direction() === Clutter.TextDirection.RTL) {
-      return Math.max(fallbackWidth, Math.round(centerBox.allocation.x1 - parent.allocation.x1));
+      const sideWidth = Math.round(centerBox.allocation.x1 - parent.allocation.x1);
+      return sideWidth > 0 ? sideWidth : fallbackWidth;
     }
 
-    return Math.max(fallbackWidth, Math.round(parent.allocation.x2 - centerBox.allocation.x2));
+    const sideWidth = Math.round(parent.allocation.x2 - centerBox.allocation.x2);
+    return sideWidth > 0 ? sideWidth : fallbackWidth;
   }
 
   private _canScrollIcons(): boolean {
@@ -502,11 +507,10 @@ export class TrayContainer extends PanelMenu.Button {
     });
 
     const visibleCount = Math.min(count, effectiveLimit);
-    const collapsedWidth = visibleCount * itemW + Math.max(0, visibleCount - 1) * ICON_GAP;
+    const naturalCollapsedWidth = visibleCount * itemW + Math.max(0, visibleCount - 1) * ICON_GAP;
     const reservedWidth =
-      availableClipWidth === null
-        ? fullWidth
-        : Math.min(fullWidth, Math.max(collapsedWidth, availableClipWidth));
+      availableClipWidth === null ? fullWidth : Math.min(fullWidth, availableClipWidth);
+    const collapsedWidth = Math.min(naturalCollapsedWidth, reservedWidth);
     const collapsedClipStart = Math.max(0, reservedWidth - collapsedWidth);
 
     // collapsed -> maxScroll anchors the row to newest icons (right-aligned in clip).
@@ -520,7 +524,7 @@ export class TrayContainer extends PanelMenu.Button {
     const startClipStart = Math.round(this._clipArea.clipStart);
 
     if (animated) {
-      logger.log(
+      logger.debug(
         `Viewport animation collapsed=${this._state.collapsed} count=${count} limit=${this._limit} effectiveLimit=${effectiveLimit} visible=${visibleCount} fullWidth=${fullWidth} reservedWidth=${reservedWidth} availableClipWidth=${availableClipWidth ?? 'none'} fromViewport=${startViewportWidth} toViewport=${targetViewportWidth} fromClipStart=${startClipStart} toClipStart=${targetClipStart} scrollOffset=${this._state.scrollOffset} chevronX=${Math.round(this._chevron.translationX)} ${this._clipArea.layoutSnapshot()}`,
         { prefix: LOG_PREFIX },
       );
@@ -564,7 +568,7 @@ export class TrayContainer extends PanelMenu.Button {
         },
         () => {
           this._applyIconOpacity();
-          logger.log(
+          logger.debug(
             `Viewport animation complete chevronX=${Math.round(this._chevron.translationX)} ${this._clipArea.layoutSnapshot()}`,
             { prefix: LOG_PREFIX },
           );
@@ -573,7 +577,7 @@ export class TrayContainer extends PanelMenu.Button {
       if (this._debugPostAllocateId > 0) GLib.Source.remove(this._debugPostAllocateId);
       this._debugPostAllocateId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
         this._debugPostAllocateId = 0;
-        logger.log(
+        logger.debug(
           `Viewport post-allocate chevronX=${Math.round(this._chevron.translationX)} ${this._clipArea.layoutSnapshot()}`,
           { prefix: LOG_PREFIX },
         );
@@ -593,6 +597,23 @@ export class TrayContainer extends PanelMenu.Button {
   private _setChevronAnchor(x: number): void {
     const rounded = Math.round(x);
     if (this._chevron.translationX !== rounded) this._chevron.translationX = rounded;
+  }
+
+  private _schedulePostAllocateRelayoutIfNeeded(): void {
+    const availableClipWidth = this._availableClipWidth(this._chevron.visible);
+    if (
+      availableClipWidth === null ||
+      Math.round(this._clipArea.reservedWidth) <= availableClipWidth ||
+      this._postAllocateRelayoutId > 0
+    ) {
+      return;
+    }
+
+    this._postAllocateRelayoutId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      this._postAllocateRelayoutId = 0;
+      this._syncLayout(false);
+      return GLib.SOURCE_REMOVE;
+    });
   }
 
   private _applyIconOpacity(): void {
@@ -616,7 +637,7 @@ export class TrayContainer extends PanelMenu.Button {
     if (this._scrollTarget === targetX) return;
     this._scrollTarget = targetX;
     if (duration > 0) {
-      logger.log(
+      logger.debug(
         `Scroll animation collapsed=${this._state.collapsed} targetX=${targetX} maxScroll=${this._maxScroll()} offset=${this._state.scrollOffset} duration=${duration}`,
         { prefix: LOG_PREFIX },
       );
@@ -644,6 +665,10 @@ export class TrayContainer extends PanelMenu.Button {
     if (this._debugPostAllocateId > 0) {
       GLib.Source.remove(this._debugPostAllocateId);
       this._debugPostAllocateId = 0;
+    }
+    if (this._postAllocateRelayoutId > 0) {
+      GLib.Source.remove(this._postAllocateRelayoutId);
+      this._postAllocateRelayoutId = 0;
     }
     destroyTooltip();
     for (const widget of this._items.values()) widget.destroy();

--- a/src/modules/trayIcons/trayIcons.ts
+++ b/src/modules/trayIcons/trayIcons.ts
@@ -99,7 +99,7 @@ export class TrayIcons extends Module {
     this._sniWatcher.start();
     this._desktopSettingsChangedId = this._desktopSettings.connect('changed::color-scheme', () => {
       const scheme = this._desktopSettings?.getString('color-scheme') ?? 'unknown';
-      logger.log(`Color scheme changed to ${scheme}; refreshing SNI icons`, {
+      logger.debug(`Color scheme changed to ${scheme}; refreshing SNI icons`, {
         prefix: LOG_PREFIX,
       });
       this._sniHost?.refreshIcons('color-scheme');
@@ -148,7 +148,7 @@ export class TrayIcons extends Module {
         }
       }),
       settings.connect('changed::tray-icons-recolor-symbolic-pixmaps', () => {
-        logger.log(
+        logger.debug(
           `Recolor symbolic SNI pixmaps=${settings.get_boolean('tray-icons-recolor-symbolic-pixmaps')}; refreshing SNI icons`,
           { prefix: LOG_PREFIX },
         );
@@ -158,7 +158,7 @@ export class TrayIcons extends Module {
   }
 
   private _onSniItemAdded(item: TrayItem): void {
-    logger.log(`SNI item added: ${item.id} (menuBus=${item.menuBusName ?? 'none'})`, {
+    logger.debug(`SNI item added: ${item.id} (menuBus=${item.menuBusName ?? 'none'})`, {
       prefix: LOG_PREFIX,
     });
     this._container?.addItem(item);
@@ -170,15 +170,15 @@ export class TrayIcons extends Module {
   }
 
   private async _onBgItemAdded(item: TrayItem, appId: string, app: Shell.App): Promise<void> {
-    logger.log(`BG app detected: ${appId}`, { prefix: LOG_PREFIX });
+    logger.debug(`BG app detected: ${appId}`, { prefix: LOG_PREFIX });
     if (this._dedupBgApps && (await this._sniCoversApp(appId, app))) {
-      logger.log(`BG app ${appId} already covered by SNI, skipping`, { prefix: LOG_PREFIX });
+      logger.debug(`BG app ${appId} already covered by SNI, skipping`, { prefix: LOG_PREFIX });
       return;
     }
     if (!this._container) return;
     this._bgItemAppIds.set(appId, { itemId: item.id, app });
     this._container.addItem(item);
-    logger.log(`BG app ${appId} added to tray`, { prefix: LOG_PREFIX });
+    logger.debug(`BG app ${appId} added to tray`, { prefix: LOG_PREFIX });
   }
 
   private async _getUniqueName(busName: string): Promise<string | null> {
@@ -223,7 +223,7 @@ export class TrayIcons extends Module {
     const owner = await this._getUniqueName(appId);
     if (owner) {
       const covered = this._sniHost?.hasItemForBus(owner) ?? false;
-      logger.log(`SNI covers ${appId}? owner=${owner} covered=${covered}`, {
+      logger.debug(`SNI covers ${appId}? owner=${owner} covered=${covered}`, {
         prefix: LOG_PREFIX,
       });
       if (covered) return true;
@@ -235,7 +235,7 @@ export class TrayIcons extends Module {
       const candidateOwner = await this._getUniqueName(candidate);
       if (!candidateOwner) continue;
       const covered = this._sniHost?.hasItemForBus(candidateOwner) ?? false;
-      logger.log(
+      logger.debug(
         `SNI covers ${appId}? candidate=${candidate} owner=${candidateOwner} covered=${covered}`,
         {
           prefix: LOG_PREFIX,
@@ -251,7 +251,7 @@ export class TrayIcons extends Module {
     // Match by SNI metadata such as DesktopEntry or Id instead.
     const coveredByMetadata =
       [...appIdCandidates].some((candidate) => this._sniHost?.hasSniForAppId(candidate)) ?? false;
-    logger.log(`SNI covers ${appId}? owner=none, metadata-match=${coveredByMetadata}`, {
+    logger.debug(`SNI covers ${appId}? owner=none, metadata-match=${coveredByMetadata}`, {
       prefix: LOG_PREFIX,
     });
     return coveredByMetadata;
@@ -261,7 +261,7 @@ export class TrayIcons extends Module {
     const appIdCandidates = this._appIdCandidates(appId, app);
     const appPids = app.get_pids?.() ?? [];
     if (appPids.length === 0) {
-      logger.log(`SNI covers ${appId}? pid-match=false app-pids=[]`, { prefix: LOG_PREFIX });
+      logger.debug(`SNI covers ${appId}? pid-match=false app-pids=[]`, { prefix: LOG_PREFIX });
     }
 
     const appPidSet = new Set(appPids);
@@ -275,7 +275,7 @@ export class TrayIcons extends Module {
       const flatpakAppId = await this._getFlatpakAppId(sniPid);
       const flatpakMatch = flatpakAppId ? appIdCandidates.has(flatpakAppId.toLowerCase()) : false;
       const covered = ancestorMatch || trackerMatch || flatpakMatch;
-      logger.log(
+      logger.debug(
         `SNI covers ${appId}? sni-bus=${busName} sni-pid=${sniPid} flatpak=${flatpakAppId ?? 'none'} app-pids=[${appPids.join(', ')}] pid-match=${covered}`,
         { prefix: LOG_PREFIX },
       );
@@ -351,13 +351,13 @@ export class TrayIcons extends Module {
   }
 
   private async _removeBgItemsCoveredBySni(): Promise<void> {
-    logger.log(`Dedup: bg items: [${[...this._bgItemAppIds.keys()].join(', ')}]`, {
+    logger.debug(`Dedup: bg items: [${[...this._bgItemAppIds.keys()].join(', ')}]`, {
       prefix: LOG_PREFIX,
     });
 
     for (const [appId, entry] of [...this._bgItemAppIds]) {
       if (await this._sniCoversApp(appId, entry.app)) {
-        logger.log(`Removing bg:${appId} covered by SNI`, { prefix: LOG_PREFIX });
+        logger.debug(`Removing bg:${appId} covered by SNI`, { prefix: LOG_PREFIX });
         this._bgItemAppIds.delete(appId);
         this._container?.removeItem(entry.itemId);
       }

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -183,7 +183,6 @@ export class AuroraDash extends Dash {
 
     (this as any).showAppsButton?.disconnectObject?.(this);
     (this as any)._box?.disconnectObject?.(this);
-    this.disconnectObject?.(this);
     Main.overview.disconnectObject(this);
     global.display.disconnectObject(this);
     global.workspace_manager.disconnectObject(this);

--- a/src/styles/_bluetooth-menu.scss
+++ b/src/styles/_bluetooth-menu.scss
@@ -10,3 +10,14 @@
   color: inherit;
   opacity: 1;
 }
+
+.aurora-bt-state-icon {
+  &.aurora-bt-state-animating,
+  &.aurora-bt-state-connected {
+    color: -st-accent-color;
+  }
+
+  &.aurora-bt-state-disconnected {
+    color: #9a9a9a;
+  }
+}

--- a/tests/shell/auroraAutoThemeSwitcher.js
+++ b/tests/shell/auroraAutoThemeSwitcher.js
@@ -45,6 +45,7 @@ export async function run() {
   const auroraSettings = getAuroraSettings();
   const desktopSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.interface' });
 
+  auroraSettings.set_boolean('module-auto-theme-switcher', true);
   await Scripting.waitLeisure();
   await Scripting.sleep(300);
 

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -36,7 +36,11 @@ const EXPECTED_MODULE_KEYS = [
   'module-bluetooth-menu',
   'module-weather-clock',
   'module-meeting-clock',
+  'module-tray-icons',
+  'module-clipboard-history',
 ] as const;
+
+const OPT_IN_MODULE_KEYS = new Set<string>(['module-auto-theme-switcher']);
 
 const schemaXml = readFileSync(SCHEMA_FILE, 'utf-8');
 
@@ -75,6 +79,7 @@ test('schema — every module key defaults to true', () => {
   while ((match = blockRe.exec(schemaXml)) !== null) {
     const block = match[0];
     const keyName = match[1];
+    if (OPT_IN_MODULE_KEYS.has(keyName)) continue;
     const defaultMatch = block.match(/<default>(.*?)<\/default>/);
     assert.ok(defaultMatch, `Key "${keyName}" has no <default> element`);
     assert.strictEqual(


### PR DESCRIPTION
- Documented the process for requesting maintenance backports via GitHub labels in CONTRIBUTING.md.
- Added a Shexli review scan command to the CI pipeline and documentation for GNOME Extensions Review.
- Updated README.md to clarify testing commands and improve readability.

fix: update Portuguese translations

- Updated the POT-Creation-Date and fixed various translation strings in pt_BR.po.

fix: change default value for auto theme switcher module

- Updated the default value for the `module-auto-theme-switcher` key in gschema.xml from true to false.

chore: enhance justfile with Shexli packaging command

- Added a new command in the justfile to run Shexli for static analysis of the extension package.

refactor: improve module disabling logic

- Refactored the disable method in AuroraShellExtension to call a new private method for disabling all modules.
- Improved BluetoothDeviceItemPatcher to handle disposal and restoration of original children more gracefully.

style: update logging levels from log to debug

- Changed logger calls from log to debug in various modules for better log level management.

fix: clean up disconnect logic in various modules

- Removed unnecessary disconnectObject calls in several modules to prevent potential errors.