### PR TITLE
fix(panel): resolve color issue for light text in panel with blur-my-shell extension

### DIFF
--- a/src/styles/_panel.scss
+++ b/src/styles/_panel.scss
@@ -36,3 +36,20 @@
 #panel:overview .panel-button#panelActivities .workspace-dot {
   background-color: vars.$aurora-panel-fg;
 }
+
+#panel.panel-light-text .panel-button,
+#panel.panel-light-text:overview .panel-button {
+  color: vars.$aurora-panel-light-text-fg;
+}
+
+#panel.panel-light-text .panel-button .system-status-icon,
+#panel.panel-light-text .panel-button .panel-status-indicators-box > .system-status-icon,
+#panel.panel-light-text:overview .panel-button .system-status-icon,
+#panel.panel-light-text:overview .panel-button .panel-status-indicators-box > .system-status-icon {
+  color: vars.$aurora-panel-light-text-fg;
+}
+
+#panel.panel-light-text .panel-button#panelActivities .workspace-dot,
+#panel.panel-light-text:overview .panel-button#panelActivities .workspace-dot {
+  background-color: vars.$aurora-panel-light-text-fg;
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -7,6 +7,7 @@ $contrast: 'normal' !default;
 
 $aurora-panel-bg: palette.$dark-1;
 $aurora-panel-fg: palette.$light-1;
+$aurora-panel-light-text-fg: palette.$light-1;
 $aurora-panel-border: none;
 $aurora-overview-bg: palette.$dark-1;
 $aurora-dash-bg: palette.$dark-1;


### PR DESCRIPTION
This pull request updates the panel styling to better support a "light text" mode by introducing a new foreground color variable and applying it to relevant panel elements. The changes ensure that text and icons in panels with the `panel-light-text` class are styled for improved readability.

**Styling improvements for light text panels:**

* Added a new SCSS variable `$aurora-panel-light-text-fg` in `src/styles/_variables.scss` to define the foreground color for light text panels.

* Updated `src/styles/_panel.scss` to:
  * Apply the new light text foreground color to panel buttons and system status icons when the `panel-light-text` class is present.
  * Ensure the workspace dot in the activities panel uses the new light text foreground color in light text mode.