### PR TITLE
feat: add dock auto-hide and multi-monitor support

### DIFF
--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aurora-shell\n"
 "Report-Msgid-Bugs-To: https://github.com/luminusOS/aurora-shell/issues\n"
-"POT-Creation-Date: 2026-07-15 09:44-0300\n"
+"POT-Creation-Date: 2026-07-15 17:04-0300\n"
 "PO-Revision-Date: 2026-03-09 18:00-0300\n"
 "Last-Translator: Aurora Shell Contributors\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -22,7 +22,9 @@ msgstr "Histórico da área de transferência"
 
 #: dist/clipboard/clipboardHistory.manifest.js:9
 msgid "Searchable clipboard history with pinning and keyboard navigation"
-msgstr "Histórico pesquisável da área de transferência, com fixação e navegação por teclado"
+msgstr ""
+"Histórico pesquisável da área de transferência, com fixação e navegação por "
+"teclado"
 
 #: dist/clipboard/clipboardHistory.manifest.js:13
 msgid "Open Shortcut"
@@ -30,7 +32,8 @@ msgstr "Atalho para abrir"
 
 #: dist/clipboard/clipboardHistory.manifest.js:14
 msgid "Keyboard shortcut to open the clipboard history panel"
-msgstr "Atalho de teclado para abrir o painel do histórico da área de transferência"
+msgstr ""
+"Atalho de teclado para abrir o painel do histórico da área de transferência"
 
 #: dist/clipboard/clipboardHistory.manifest.js:19
 msgid "Paste Automatically"
@@ -124,7 +127,8 @@ msgstr "Recolhimento automático de atenção (segundos)"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:31
 msgid "Seconds before the tray collapses after a notification icon appears"
-msgstr "Segundos até a bandeja ser recolhida após aparecer um ícone de notificação"
+msgstr ""
+"Segundos até a bandeja ser recolhida após aparecer um ícone de notificação"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:38
 msgid "Hide Background App When Tray Icon Present"
@@ -132,7 +136,9 @@ msgstr "Ocultar aplicativo em segundo plano quando houver ícone na bandeja"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:39
 msgid "Remove the background app icon when the same app has an SNI tray icon"
-msgstr "Remove o ícone do aplicativo em segundo plano quando o mesmo aplicativo tiver um ícone SNI na bandeja"
+msgstr ""
+"Remove o ícone do aplicativo em segundo plano quando o mesmo aplicativo "
+"tiver um ícone SNI na bandeja"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:44
 msgid "Hide Background Apps from Quick Settings"
@@ -140,7 +146,9 @@ msgstr "Ocultar aplicativos em segundo plano das Configurações Rápidas"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:45
 msgid "Hide the Background Apps section from the Quick Settings dropdown"
-msgstr "Oculta a seção Aplicativos em segundo plano do menu suspenso de Configurações Rápidas"
+msgstr ""
+"Oculta a seção Aplicativos em segundo plano do menu suspenso de "
+"Configurações Rápidas"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:50
 msgid "Recolor Symbolic Tray Icons"
@@ -148,7 +156,9 @@ msgstr "Recolorir ícones simbólicos da bandeja"
 
 #: dist/desktop/trayIcons/trayIcons.manifest.js:51
 msgid "Automatically recolor monochrome SNI icons to match the panel theme"
-msgstr "Recolore automaticamente ícones SNI monocromáticos para corresponder ao tema do painel"
+msgstr ""
+"Recolore automaticamente ícones SNI monocromáticos para corresponder ao tema "
+"do painel"
 
 #: dist/dock/dock.manifest.js:8
 msgid "Dock"
@@ -165,21 +175,44 @@ msgstr "Sempre mostrar dock"
 #: dist/dock/dock.manifest.js:14
 msgid ""
 "Keep dock permanently visible and shrink windows so they never overlap it"
-msgstr "Mantém o dock sempre visível e reduz as janelas para que nunca o sobreponham"
+msgstr ""
+"Mantém o dock sempre visível e reduz as janelas para que nunca o sobreponham"
 
 #: dist/dock/dock.manifest.js:19
+msgid "Always Auto-Hide Dock"
+msgstr "Sempre ocultar dock automaticamente"
+
+#: dist/dock/dock.manifest.js:20
+msgid "Keep the dock hidden until the pointer reaches the screen edge"
+msgstr "Mantém o dock oculto até o ponteiro alcançar a borda da tela"
+
+#: dist/dock/dock.manifest.js:25
+msgid "Show Dock on All Monitors"
+msgstr "Mostrar dock em todos os monitores"
+
+#: dist/dock/dock.manifest.js:27
+msgid ""
+"Create a separate dock for each monitor; otherwise, the primary dock shows "
+"all workspace apps"
+msgstr ""
+"Cria um dock separado para cada monitor; caso contrário, o dock principal "
+"mostra todos os aplicativos do espaço de trabalho"
+
+#: dist/dock/dock.manifest.js:33
 msgid "Show Trash Icon"
 msgstr "Mostrar ícone da lixeira"
 
-#: dist/dock/dock.manifest.js:20
+#: dist/dock/dock.manifest.js:34
 msgid "Show a trash can in the dock; click to open it, right-click to empty it"
-msgstr "Mostra uma lixeira no dock; clique para abri-la e clique com o botão direito para esvaziá-la"
+msgstr ""
+"Mostra uma lixeira no dock; clique para abri-la e clique com o botão direito "
+"para esvaziá-la"
 
-#: dist/dock/dock.manifest.js:25
+#: dist/dock/dock.manifest.js:39
 msgid "Show External Storage"
 msgstr "Mostrar armazenamento externo"
 
-#: dist/dock/dock.manifest.js:26
+#: dist/dock/dock.manifest.js:40
 msgid "Show removable drives in the dock when they are connected"
 msgstr "Mostra unidades removíveis no dock quando estão conectadas"
 
@@ -229,48 +262,48 @@ msgstr "Comportamento"
 msgid "Privacy &amp; Clipboard"
 msgstr "Privacidade e área de transferência"
 
-#: dist/panel/auroraMenu.js:119
+#: dist/panel/auroraMenu.js:121
 msgid "About This PC"
 msgstr "Sobre este computador"
 
-#: dist/panel/auroraMenu.js:126
+#: dist/panel/auroraMenu.js:128
 msgid "Home Folder"
 msgstr "Pasta pessoal"
 
-#: dist/panel/auroraMenu.js:132
+#: dist/panel/auroraMenu.js:134
 msgid "Downloads"
 msgstr "Downloads"
 
-#: dist/panel/auroraMenu.js:142
+#: dist/panel/auroraMenu.js:144
 msgid "System Settings"
 msgstr "Configurações do sistema"
 
-#: dist/panel/auroraMenu.js:148
+#: dist/panel/auroraMenu.js:150
 msgid "Software"
 msgstr "Aplicativos"
 
-#: dist/panel/auroraMenu.js:154
+#: dist/panel/auroraMenu.js:156
 msgid "Extensions"
 msgstr "Extensões"
 
-#: dist/panel/auroraMenu.js:211
+#: dist/panel/auroraMenu.js:213
 msgid "Recent Items"
 msgstr "Itens recentes"
 
-#: dist/panel/auroraMenu.js:217
+#: dist/panel/auroraMenu.js:219
 msgid "No recent items"
 msgstr "Nenhum item recente"
 
-#: dist/panel/auroraMenu.js:339 dist/panel/auroraMenu.js:352
-#: dist/panel/auroraMenu.js:374 dist/panel/auroraMenu.manifest.js:8
+#: dist/panel/auroraMenu.js:341 dist/panel/auroraMenu.js:354
+#: dist/panel/auroraMenu.js:376 dist/panel/auroraMenu.manifest.js:8
 msgid "Aurora Menu"
 msgstr "Menu Aurora"
 
-#: dist/panel/auroraMenu.js:339 dist/panel/auroraMenu.js:352
+#: dist/panel/auroraMenu.js:341 dist/panel/auroraMenu.js:354
 msgid "Could not launch the selected command."
 msgstr "Não foi possível iniciar o comando selecionado."
 
-#: dist/panel/auroraMenu.js:374
+#: dist/panel/auroraMenu.js:376
 msgid "Could not open the selected recent item."
 msgstr "Não foi possível abrir o item recente selecionado."
 
@@ -385,29 +418,31 @@ msgstr "Menu Bluetooth"
 #: dist/panel/bluetoothMenu/bluetoothMenu.manifest.js:9
 msgid ""
 "Shows battery level and animated icons in the Bluetooth Quick Settings panel"
-msgstr "Mostra o nível da bateria e ícones animados no painel de Configurações Rápidas do Bluetooth"
+msgstr ""
+"Mostra o nível da bateria e ícones animados no painel de Configurações "
+"Rápidas do Bluetooth"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:325
+#: dist/panel/clock/meetingClock/meetingClock.js:332
 msgid "Meeting starting soon"
 msgstr "Reunião começará em breve"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:333
+#: dist/panel/clock/meetingClock/meetingClock.js:340
 msgid "Join"
 msgstr "Participar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:334
+#: dist/panel/clock/meetingClock/meetingClock.js:341
 msgid "Snooze"
 msgstr "Adiar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:335
+#: dist/panel/clock/meetingClock/meetingClock.js:342
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:336
+#: dist/panel/clock/meetingClock/meetingClock.js:343
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:497
+#: dist/panel/clock/meetingClock/meetingClock.js:504
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:8
 msgid "Meeting Clock"
 msgstr "Relógio de reuniões"
@@ -446,7 +481,9 @@ msgstr "Alertar eventos sem links"
 
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:36
 msgid "Show meeting alerts for calendar events that do not include a join link"
-msgstr "Mostra alertas de reunião para eventos do calendário que não incluem um link para participar"
+msgstr ""
+"Mostra alertas de reunião para eventos do calendário que não incluem um link "
+"para participar"
 
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:41
 msgid "Panel Reveal Interval (minutes)"
@@ -454,7 +491,9 @@ msgstr "Intervalo de revelação do painel (minutos)"
 
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:42
 msgid "Minutes between automatic Meeting Clock slide reveals in the panel"
-msgstr "Minutos entre as revelações automáticas deslizantes do Relógio de reuniões no painel"
+msgstr ""
+"Minutos entre as revelações automáticas deslizantes do Relógio de reuniões "
+"no painel"
 
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:49
 msgid "Panel Lookahead (minutes)"
@@ -463,7 +502,9 @@ msgstr "Antecedência do painel (minutos)"
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:50
 msgid ""
 "Maximum minutes before an event starts for it to appear in the panel clock"
-msgstr "Máximo de minutos antes do início de um evento para ele aparecer no relógio do painel"
+msgstr ""
+"Máximo de minutos antes do início de um evento para ele aparecer no relógio "
+"do painel"
 
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:57
 msgid "Hide All-Day Events"
@@ -503,7 +544,8 @@ msgstr "Porcentagem de bateria baixa"
 
 #: dist/panel/lowBatteryPercentage.manifest.js:9
 msgid "Shows battery percentage in the panel while below 20%"
-msgstr "Mostra a porcentagem da bateria no painel enquanto estiver abaixo de 20%"
+msgstr ""
+"Mostra a porcentagem da bateria no painel enquanto estiver abaixo de 20%"
 
 #: dist/panel/volumeMixer/mixerItem.js:94
 msgid "Unknown"
@@ -517,17 +559,17 @@ msgstr "Nenhum áudio em reprodução"
 msgid "Volume changed"
 msgstr "Volume alterado"
 
-#: dist/panel/volumeMixer/volumeMixer.js:90
+#: dist/panel/volumeMixer/volumeMixer.js:76
 msgid "Sound Settings"
 msgstr "Configurações de som"
 
-#: dist/panel/volumeMixer/volumeMixer.js:108
-#: dist/panel/volumeMixer/volumeMixer.js:117
+#: dist/panel/volumeMixer/volumeMixer.js:94
+#: dist/panel/volumeMixer/volumeMixer.js:104
 #: dist/panel/volumeMixer/volumeMixer.manifest.js:8
 msgid "Volume Mixer"
 msgstr "Mixer de Volume"
 
-#: dist/panel/volumeMixer/volumeMixer.js:126
+#: dist/panel/volumeMixer/volumeMixer.js:114
 msgid "Sound Output"
 msgstr "Saída de som"
 
@@ -541,7 +583,9 @@ msgstr "Dica de pesquisa de aplicativos"
 
 #: dist/patches/appSearchTooltip.manifest.js:9
 msgid "Shows app name on hover in the overview search results"
-msgstr "Mostra o nome do aplicativo ao passar o cursor sobre os resultados da pesquisa na visão geral"
+msgstr ""
+"Mostra o nome do aplicativo ao passar o cursor sobre os resultados da "
+"pesquisa na visão geral"
 
 #: dist/patches/focusLaunchedWindows.manifest.js:8
 msgid "Focus Launched Windows"
@@ -550,7 +594,8 @@ msgstr "Focar janelas iniciadas"
 #: dist/patches/focusLaunchedWindows.manifest.js:9
 msgid ""
 "Focuses newly launched windows instead of showing window-ready notifications"
-msgstr "Foca janelas recém-iniciadas em vez de mostrar notificações de janela pronta"
+msgstr ""
+"Foca janelas recém-iniciadas em vez de mostrar notificações de janela pronta"
 
 #: dist/patches/iconWeave.manifest.js:8
 msgid "Icon Weave"
@@ -558,7 +603,9 @@ msgstr "Trama de ícones"
 
 #: dist/patches/iconWeave.manifest.js:9
 msgid "Automatically fixes missing app icons using an in-memory approach"
-msgstr "Corrige automaticamente ícones de aplicativos ausentes usando uma abordagem em memória"
+msgstr ""
+"Corrige automaticamente ícones de aplicativos ausentes usando uma abordagem "
+"em memória"
 
 #: dist/patches/noOverview.manifest.js:8
 msgid "Skip Overview on Login"
@@ -566,7 +613,8 @@ msgstr "Pular visão geral ao iniciar sessão"
 
 #: dist/patches/noOverview.manifest.js:9
 msgid "Goes directly to the desktop when GNOME Shell starts"
-msgstr "Vai diretamente para a área de trabalho quando o GNOME Shell é iniciado"
+msgstr ""
+"Vai diretamente para a área de trabalho quando o GNOME Shell é iniciado"
 
 #: dist/patches/pipOnTop.manifest.js:8
 msgid "Pip On Top"
@@ -592,7 +640,9 @@ msgstr "Usar alternativa do GNOME Shell"
 msgid ""
 "Use GNOME Shell only when the Vela D-Bus service or control API is "
 "unavailable"
-msgstr "Usa o GNOME Shell apenas quando o serviço D-Bus ou a API de controle do Vela não estiver disponível"
+msgstr ""
+"Usa o GNOME Shell apenas quando o serviço D-Bus ou a API de controle do Vela "
+"não estiver disponível"
 
 #: dist/patches/xwaylandIndicator.manifest.js:8
 msgid "XWayland Indicator"
@@ -649,7 +699,9 @@ msgstr "Painel de privacidade"
 #: dist/privacy/privacy.manifest.js:20
 msgid ""
 "Hides panel content during screen sharing; shows only the sharing indicator"
-msgstr "Oculta o conteúdo do painel durante o compartilhamento de tela; mostra apenas o indicador de compartilhamento"
+msgstr ""
+"Oculta o conteúdo do painel durante o compartilhamento de tela; mostra "
+"apenas o indicador de compartilhamento"
 
 #: dist/theme/autoThemeSwitcher.manifest.js:8
 msgid "Auto Theme Switcher"
@@ -657,7 +709,8 @@ msgstr "Alternador automático de tema"
 
 #: dist/theme/autoThemeSwitcher.manifest.js:9
 msgid "Automatically switches between light and dark theme based on time"
-msgstr "Alterna automaticamente entre os temas claro e escuro com base no horário"
+msgstr ""
+"Alterna automaticamente entre os temas claro e escuro com base no horário"
 
 #: dist/theme/autoThemeSwitcher.manifest.js:14
 msgid "Light Time"
@@ -682,6 +735,9 @@ msgstr "Alternador de Tema"
 #: dist/theme/themeChanger.manifest.js:9
 msgid "Monitors and synchronizes GNOME color scheme"
 msgstr "Monitora e sincroniza o esquema de cores do GNOME"
+
+#~ msgid "When disabled, show the dock only on the primary monitor"
+#~ msgstr "Quando desativado, mostra o dock somente no monitor principal"
 
 #~ msgid "No Overview"
 #~ msgstr "Sem Visão Geral"

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -76,6 +76,16 @@
       <summary>Always show dock</summary>
       <description>Keep the dock permanently visible and reserve screen space so windows never overlap it</description>
     </key>
+    <key name="dock-always-autohide" type="b">
+      <default>false</default>
+      <summary>Always auto-hide dock</summary>
+      <description>Keep the dock hidden until the pointer reaches the screen edge, regardless of window overlap</description>
+    </key>
+    <key name="dock-show-on-all-monitors" type="b">
+      <default>false</default>
+      <summary>Show dock on all monitors</summary>
+      <description>Show the dock on every eligible monitor instead of only on the primary monitor</description>
+    </key>
     <key name="dock-show-trash" type="b">
       <default>true</default>
       <summary>Show trash icon</summary>

--- a/src/dev/dockDevTool.ts
+++ b/src/dev/dockDevTool.ts
@@ -30,7 +30,7 @@ export class DockDevTool {
       createDevToolSummary(
         this.iconName,
         dock
-          ? `Bindings: ${dock.bindings.length} · Always-show: ${dock.alwaysShow ? 'on' : 'off'}`
+          ? `Bindings: ${dock.bindings.length} · Always-show: ${dock.alwaysShow ? 'on' : 'off'} · Always-autohide: ${dock.alwaysAutoHide ? 'on' : 'off'}`
           : 'Dock disabled',
       ),
     );
@@ -162,7 +162,7 @@ export class DockDevTool {
   private _monitorStatus(binding: ManagedDockBinding): string {
     let intellihide: string;
     if (!binding.intellihide) {
-      intellihide = 'always-show';
+      intellihide = binding.mode;
     } else if (binding.intellihide.status === OverlapStatus.CLEAR) {
       intellihide = 'clear';
     } else {

--- a/src/dock/dock.manifest.ts
+++ b/src/dock/dock.manifest.ts
@@ -15,6 +15,20 @@ export const manifest: ModuleManifest = {
       type: 'switch',
     },
     {
+      key: 'dock-always-autohide',
+      title: _('Always Auto-Hide Dock'),
+      subtitle: _('Keep the dock hidden until the pointer reaches the screen edge'),
+      type: 'switch',
+    },
+    {
+      key: 'dock-show-on-all-monitors',
+      title: _('Show Dock on All Monitors'),
+      subtitle: _(
+        'Create a separate dock for each monitor; otherwise, the primary dock shows all workspace apps',
+      ),
+      type: 'switch',
+    },
+    {
       key: 'dock-show-trash',
       title: _('Show Trash Icon'),
       subtitle: _('Show a trash can in the dock; click to open it, right-click to empty it'),

--- a/src/dock/dock.ts
+++ b/src/dock/dock.ts
@@ -13,7 +13,7 @@ import { Module } from '~/module.ts';
 import { AuroraDash, type DashBounds } from '~/shared/ui/dash.ts';
 import { DockHotArea } from '~/dock/hotArea.ts';
 import { DockIntellihide, OverlapStatus } from '~/dock/intellihide.ts';
-import { hasDefinedBottom } from '~/dock/monitorTopology.ts';
+import { getDockMonitorIndexes } from '~/dock/monitorTopology.ts';
 
 const HOT_AREA_REVEAL_DURATION = 1500;
 const HOT_AREA_STRIP_HEIGHT = 1;
@@ -21,6 +21,7 @@ const LOG_PREFIX = 'Dock';
 
 export type ManagedDockBinding = {
   monitorIndex: number;
+  mode: 'always-show' | 'always-autohide' | 'intellihide';
   container: St.Bin;
   dash: AuroraDash;
   intellihide: InstanceType<typeof DockIntellihide> | null;
@@ -37,6 +38,8 @@ export class Dock extends Module {
   private _pendingRebuild = false;
   private _dockSettings: any = null;
   private _alwaysShow = false;
+  private _alwaysAutoHide = false;
+  private _showOnAllMonitors = false;
   private _showTrash = true;
   private _showExternalStorage = true;
 
@@ -48,11 +51,17 @@ export class Dock extends Module {
     this._lifecycle = new LifecycleScope();
     this._dockSettings = this.context.settings.getRawSettings();
     this._alwaysShow = this._dockSettings?.get_boolean('dock-always-show') ?? false;
+    this._alwaysAutoHide = this._dockSettings?.get_boolean('dock-always-autohide') ?? false;
+    if (this._alwaysShow && this._alwaysAutoHide) {
+      this._alwaysAutoHide = false;
+      this._dockSettings?.set_boolean('dock-always-autohide', false);
+    }
+    this._showOnAllMonitors = this._dockSettings?.get_boolean('dock-show-on-all-monitors') ?? false;
     this._showTrash = this._dockSettings?.get_boolean('dock-show-trash') ?? true;
     this._showExternalStorage =
       this._dockSettings?.get_boolean('dock-show-external-storage') ?? true;
     logger.debug(
-      `enable alwaysShow=${this._alwaysShow} showTrash=${this._showTrash} showExternalStorage=${this._showExternalStorage} monitors=${Main.layoutManager.monitors?.length ?? 0}`,
+      `enable alwaysShow=${this._alwaysShow} alwaysAutoHide=${this._alwaysAutoHide} showOnAllMonitors=${this._showOnAllMonitors} showTrash=${this._showTrash} showExternalStorage=${this._showExternalStorage} monitors=${Main.layoutManager.monitors?.length ?? 0}`,
       { prefix: LOG_PREFIX },
     );
 
@@ -89,6 +98,25 @@ export class Dock extends Module {
       'changed::dock-always-show',
       () => {
         this._alwaysShow = this._dockSettings?.get_boolean('dock-always-show') ?? false;
+        if (this._alwaysShow && this._alwaysAutoHide) {
+          this._dockSettings?.set_boolean('dock-always-autohide', false);
+          return;
+        }
+        this._rebuildBindings();
+      },
+      'changed::dock-always-autohide',
+      () => {
+        this._alwaysAutoHide = this._dockSettings?.get_boolean('dock-always-autohide') ?? false;
+        if (this._alwaysAutoHide && this._alwaysShow) {
+          this._dockSettings?.set_boolean('dock-always-show', false);
+          return;
+        }
+        this._rebuildBindings();
+      },
+      'changed::dock-show-on-all-monitors',
+      () => {
+        this._showOnAllMonitors =
+          this._dockSettings?.get_boolean('dock-show-on-all-monitors') ?? false;
         this._rebuildBindings();
       },
       'changed::dock-show-trash',
@@ -125,6 +153,10 @@ export class Dock extends Module {
 
   get alwaysShow(): boolean {
     return this.context.settings.getBoolean('dock-always-show');
+  }
+
+  get alwaysAutoHide(): boolean {
+    return this.context.settings.getBoolean('dock-always-autohide');
   }
 
   toggleAlwaysShow(): boolean {
@@ -201,25 +233,28 @@ export class Dock extends Module {
     this._clearBindings();
 
     const monitors: DashBounds[] = Main.layoutManager.monitors ?? [];
+    const primaryIndex = Main.layoutManager.primaryIndex;
+    const monitorIndexes = getDockMonitorIndexes(monitors, primaryIndex, this._showOnAllMonitors);
     logger.debug(
-      `rebuild monitors=[${monitors.map((monitor, index) => `${index}:${monitor.x},${monitor.y} ${monitor.width}x${monitor.height}`).join(';')}]`,
+      `rebuild primary=${primaryIndex} showOnAllMonitors=${this._showOnAllMonitors} selected=[${monitorIndexes.join(',')}] monitors=[${monitors.map((monitor, index) => `${index}:${monitor.x},${monitor.y} ${monitor.width}x${monitor.height}`).join(';')}]`,
       { prefix: LOG_PREFIX },
     );
-    monitors.forEach((monitor, index) => {
-      if (hasDefinedBottom(monitors, index)) {
-        const binding = this._createBinding(monitor, index);
-        if (binding) this._bindings.set(index, binding);
-      } else {
-        logger.debug(`monitor=${index} skipped because another monitor is below it`, {
-          prefix: LOG_PREFIX,
-        });
-      }
+    monitorIndexes.forEach((monitorIndex) => {
+      const monitor = monitors[monitorIndex];
+      if (!monitor) return;
+      const binding = this._createBinding(monitor, monitorIndex);
+      if (binding) this._bindings.set(monitorIndex, binding);
     });
 
     this._refreshWorkAreas();
   }
 
   private _createBinding(monitor: DashBounds, monitorIndex: number): ManagedDockBinding | null {
+    const mode = this._alwaysShow
+      ? 'always-show'
+      : this._alwaysAutoHide
+        ? 'always-autohide'
+        : 'intellihide';
     // In always-show mode the strutActor must be added to uiGroup BEFORE the
     // container. Both are inserted via addChrome (→ uiGroup.add_child), so the
     // one added first sits lower in Z-order. The DnD system uses PickMode.ALL
@@ -240,10 +275,12 @@ export class Dock extends Module {
 
     const dash = new (AuroraDash as unknown as new (p: {
       monitorIndex: number;
+      isolateMonitor: boolean;
       showTrash: boolean;
       showExternalStorage: boolean;
     }) => AuroraDash)({
       monitorIndex,
+      isolateMonitor: this._showOnAllMonitors,
       showTrash: this._showTrash,
       showExternalStorage: this._showExternalStorage,
     });
@@ -252,6 +289,7 @@ export class Dock extends Module {
 
     const binding: ManagedDockBinding = {
       monitorIndex,
+      mode,
       container,
       dash,
       intellihide: null,
@@ -262,7 +300,7 @@ export class Dock extends Module {
       hotAreaActive: false,
     };
     logger.debug(
-      `monitor=${monitorIndex} binding created geometry=${monitor.x},${monitor.y} ${monitor.width}x${monitor.height} mode=${this._alwaysShow ? 'always-show' : 'intellihide'}`,
+      `monitor=${monitorIndex} binding created geometry=${monitor.x},${monitor.y} ${monitor.width}x${monitor.height} mode=${mode}`,
       { prefix: LOG_PREFIX },
     );
 
@@ -276,11 +314,17 @@ export class Dock extends Module {
         this,
       );
     } else {
+      binding.hotArea = this._createHotArea(binding, monitor);
+
+      if (this._alwaysAutoHide) {
+        dash.forceAutoHide(false);
+        this._enableHotAreaWhenDockHidden(binding);
+        return binding;
+      }
+
       const intellihide = new DockIntellihide(monitorIndex);
       binding.intellihide = intellihide;
       dash.setTargetBoxListener((box) => intellihide.updateTargetBox(box));
-
-      binding.hotArea = this._createHotArea(binding, monitor);
 
       intellihide.connectObject(
         'status-changed',
@@ -533,7 +577,7 @@ export class Dock extends Module {
   // dash's native hover-based autohide (stays while hovered, hides on leave);
   // when nothing is blocking, keep it pinned visible.
   private _releaseHotAreaToAutoHide(binding: ManagedDockBinding): void {
-    if (binding.intellihide?.status === OverlapStatus.CLEAR) {
+    if (binding.mode === 'intellihide' && binding.intellihide?.status === OverlapStatus.CLEAR) {
       logger.debug(`monitor=${binding.monitorIndex} hot-area reveal kept visible: CLEAR`, {
         prefix: LOG_PREFIX,
       });
@@ -592,6 +636,9 @@ export class Dock extends Module {
         this._updateWorkArea(binding);
         if (this._alwaysShow) {
           binding.dash.blockAutoHide(true);
+        } else if (this._alwaysAutoHide) {
+          binding.dash.forceAutoHide(false);
+          this._enableHotAreaWhenDockHidden(binding);
         } else {
           binding.intellihide?.refresh('overview-hidden', true);
         }

--- a/src/dock/monitorTopology.ts
+++ b/src/dock/monitorTopology.ts
@@ -21,3 +21,23 @@ export function hasDefinedBottom(monitors: DashBounds[], index: number): boolean
     return other.y >= bottom && other.x < right && other.x + other.width > left;
   });
 }
+
+/**
+ * Returns the monitor indexes that should receive a dock.
+ *
+ * Primary-only mode deliberately ignores the vertical-topology safeguard: the
+ * configured primary monitor must keep its dock even when another display is
+ * positioned below it. All-monitors mode keeps the safeguard so a dock is not
+ * placed on an internal edge between vertically stacked displays.
+ */
+export function getDockMonitorIndexes(
+  monitors: DashBounds[],
+  primaryIndex: number,
+  showOnAllMonitors: boolean,
+): number[] {
+  if (!showOnAllMonitors) {
+    return primaryIndex >= 0 && primaryIndex < monitors.length ? [primaryIndex] : [];
+  }
+
+  return monitors.flatMap((_monitor, index) => (hasDefinedBottom(monitors, index) ? [index] : []));
+}

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -43,6 +43,7 @@ type VisibilityTarget = 'shown' | 'hidden';
 
 interface AuroraDashParams {
   monitorIndex?: number;
+  isolateMonitor?: boolean;
   showTrash?: boolean;
   showExternalStorage?: boolean;
 }
@@ -57,6 +58,7 @@ type DashInternals = {
 @GObject.registerClass
 export class AuroraDash extends Dash {
   declare private _monitorIndex: number;
+  declare private _isolateMonitor: boolean;
   private _workArea: DashBounds | null = null;
   private _container: St.Bin | null = null;
   private _autohideTimeoutId = 0;
@@ -89,6 +91,7 @@ export class AuroraDash extends Dash {
     this._trashIcon = null;
     this._externalStorageIcons = [];
     this._monitorIndex = params.monitorIndex ?? Main.layoutManager.primaryIndex;
+    this._isolateMonitor = params.isolateMonitor ?? true;
     this._unredirectInhibitor = new UnredirectInhibitor(global.compositor);
     this.connect('notify::mapped', () => this._unredirectInhibitor.setInhibited(this.mapped));
 
@@ -799,10 +802,11 @@ export class AuroraDash extends Dash {
       }
     }
 
-    // Temporarily patch get_running() so the base Dash only sees apps with
-    // windows on this monitor and active workspace. _globallyRunningIds is set
-    // so the _createAppItem.destroy patch can distinguish actual closes (animate
-    // out) from workspace-filter removals (instant destroy, no ghost icons).
+    // Temporarily patch get_running() so the base Dash only sees apps in the
+    // active workspace. Per-monitor docks also isolate their apps by monitor;
+    // the single primary dock aggregates apps from every monitor instead.
+    // _globallyRunningIds lets the _createAppItem.destroy patch distinguish
+    // actual closes from scope-filter removals (instant destroy, no ghost icons).
     const appSystem = dashAny._appSystem;
     const origGetRunning = appSystem?.get_running;
     if (appSystem && origGetRunning) {
@@ -885,7 +889,7 @@ export class AuroraDash extends Dash {
 
   private _isWindowRelevant(w: any): boolean {
     return (
-      w.get_monitor() === this._monitorIndex &&
+      (!this._isolateMonitor || w.get_monitor() === this._monitorIndex) &&
       (w.is_on_all_workspaces?.() ||
         w.get_workspace() === global.workspace_manager.get_active_workspace())
     );

--- a/tests/shell/auroraDock.js
+++ b/tests/shell/auroraDock.js
@@ -107,6 +107,18 @@ export function init() {
     'Intellihide keeps the dock actor stable on external monitors in workspace two',
   );
   Scripting.defineScriptEvent(
+    'primaryMonitorOnly',
+    'Primary-only Dock aggregates active-workspace apps from every monitor',
+  );
+  Scripting.defineScriptEvent(
+    'allMonitorsEnabled',
+    'Per-monitor Docks isolate active-workspace apps to their own monitor',
+  );
+  Scripting.defineScriptEvent(
+    'alwaysAutoHideIndependent',
+    'Always auto-hide remains hidden without relying on window overlap',
+  );
+  Scripting.defineScriptEvent(
     'externalStorageDisabled',
     'External storage dock icons are absent when disabled',
   );
@@ -126,9 +138,13 @@ export async function run() {
   const originalShowTrash = settings.get_boolean('dock-show-trash');
   const originalShowExternalStorage = settings.get_boolean('dock-show-external-storage');
   const originalAlwaysShow = settings.get_boolean('dock-always-show');
+  const originalAlwaysAutoHide = settings.get_boolean('dock-always-autohide');
+  const originalShowOnAllMonitors = settings.get_boolean('dock-show-on-all-monitors');
   settings.set_boolean('dock-show-trash', true);
   settings.set_boolean('dock-show-external-storage', false);
   settings.set_boolean('dock-always-show', false);
+  settings.set_boolean('dock-always-autohide', false);
+  settings.set_boolean('dock-show-on-all-monitors', false);
 
   await Scripting.waitLeisure();
   await Scripting.sleep(500);
@@ -151,6 +167,53 @@ export async function run() {
   // I3 — trash uses the regular icon and sits directly before Show Apps
   const extension = Main.extensionManager.lookup(EXTENSION_UUID);
   const dock = extension?.stateObj?._modules?.get('dock');
+
+  if (
+    dock?.bindings?.length !== 1 ||
+    dock.bindings[0]?.monitorIndex !== Main.layoutManager.primaryIndex
+  ) {
+    throw new Error(
+      `Primary-only Dock expected one binding on monitor ${Main.layoutManager.primaryIndex}, got ${dock?.bindings?.map((binding) => binding.monitorIndex).join(',')}`,
+    );
+  }
+
+  const externalMonitorIndex = Main.layoutManager.monitors.findIndex(
+    (_monitor, index) => index !== Main.layoutManager.primaryIndex,
+  );
+  if (externalMonitorIndex < 0)
+    throw new Error('Primary-only Dock scope test requires an external monitor');
+
+  const externalWorkspaceWindow = {
+    get_monitor: () => externalMonitorIndex,
+    is_on_all_workspaces: () => false,
+    get_workspace: () => global.workspace_manager.get_active_workspace(),
+  };
+  if (!dock.bindings[0].dash._isWindowRelevant(externalWorkspaceWindow))
+    throw new Error('Primary-only Dock excluded an app from an external monitor');
+  Scripting.scriptEvent('primaryMonitorOnly');
+
+  settings.set_boolean('dock-show-on-all-monitors', true);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+  if (dock.bindings.length !== Main.layoutManager.monitors.length) {
+    throw new Error(
+      `All-monitors Dock expected ${Main.layoutManager.monitors.length} bindings, got ${dock.bindings.length}`,
+    );
+  }
+  const primaryBinding = dock.bindings.find(
+    (candidate) => candidate.monitorIndex === Main.layoutManager.primaryIndex,
+  );
+  const externalBinding = dock.bindings.find(
+    (candidate) => candidate.monitorIndex === externalMonitorIndex,
+  );
+  if (!primaryBinding || !externalBinding)
+    throw new Error('All-monitors Dock did not create the bindings needed for scope validation');
+  if (primaryBinding.dash._isWindowRelevant(externalWorkspaceWindow))
+    throw new Error('Primary per-monitor Dock included an app from an external monitor');
+  if (!externalBinding.dash._isWindowRelevant(externalWorkspaceWindow))
+    throw new Error('External per-monitor Dock excluded an app from its own monitor');
+  Scripting.scriptEvent('allMonitorsEnabled');
+
   const dash = dock?.bindings?.[0]?.dash;
   const showAppsIcon = dash?._showAppsIcon;
   const dashChildren = dash?._dashContainer?.get_children?.() ?? [];
@@ -689,6 +752,40 @@ export async function run() {
   clearIntellihideQueuedRefreshes(binding.intellihide);
   Scripting.scriptEvent('intellihideFlapDebounced');
 
+  // Always auto-hide must bypass intellihide completely: with no overlap
+  // decision involved, it starts hidden and only appears through the hot area.
+  settings.set_boolean('dock-always-autohide', true);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+  const alwaysAutoHideBinding = dock.bindings.find(
+    (candidate) => candidate.monitorIndex === Main.layoutManager.primaryIndex,
+  );
+  if (!alwaysAutoHideBinding)
+    throw new Error('Always auto-hide did not retain a binding on the primary monitor');
+  if (alwaysAutoHideBinding.mode !== 'always-autohide' || alwaysAutoHideBinding.intellihide)
+    throw new Error('Always auto-hide still depends on intellihide window state');
+  if (alwaysAutoHideBinding.dash.visible)
+    throw new Error('Always auto-hide Dock was visible before an edge reveal');
+
+  const originalAlwaysAutoHideHover = alwaysAutoHideBinding.dash._dashContainerHasHover;
+  alwaysAutoHideBinding.dash._dashContainerHasHover = () => false;
+  try {
+    if (!dock.revealMonitorFromHotArea(alwaysAutoHideBinding.monitorIndex))
+      throw new Error('Always auto-hide Dock could not be revealed from its hot area');
+    await Scripting.sleep(100);
+    if (!alwaysAutoHideBinding.dash.visible)
+      throw new Error('Always auto-hide Dock did not appear after an edge reveal');
+
+    dock._clearHotAreaReveal(alwaysAutoHideBinding);
+    dock._releaseHotAreaToAutoHide(alwaysAutoHideBinding);
+    await Scripting.sleep(500);
+    if (alwaysAutoHideBinding.dash.visible)
+      throw new Error('Always auto-hide Dock stayed visible after the reveal ended');
+  } finally {
+    alwaysAutoHideBinding.dash._dashContainerHasHover = originalAlwaysAutoHideHover;
+  }
+  Scripting.scriptEvent('alwaysAutoHideIndependent');
+
   // I11 — disable dock, actor must be removed
   const originalValue = settings.get_boolean('module-dock');
   settings.set_boolean('module-dock', false);
@@ -707,6 +804,8 @@ export async function run() {
   settings.set_boolean('dock-show-trash', originalShowTrash);
   settings.set_boolean('dock-show-external-storage', originalShowExternalStorage);
   settings.set_boolean('dock-always-show', originalAlwaysShow);
+  settings.set_boolean('dock-always-autohide', originalAlwaysAutoHide);
+  settings.set_boolean('dock-show-on-all-monitors', originalShowOnAllMonitors);
   settings.set_boolean('module-dock', originalValue);
   await Scripting.waitLeisure();
   await Scripting.sleep(300);
@@ -728,6 +827,9 @@ let _dockRemoved = false;
 let _externalStorageDisabled = false;
 let _iconResizeCountsFixedIcons = false;
 let _externalWorkspaceActorStable = false;
+let _primaryMonitorOnly = false;
+let _allMonitorsEnabled = false;
+let _alwaysAutoHideIndependent = false;
 
 /** @returns {void} */
 export function script_dockPresent() {
@@ -810,6 +912,21 @@ export function script_externalWorkspaceActorStable() {
 }
 
 /** @returns {void} */
+export function script_primaryMonitorOnly() {
+  _primaryMonitorOnly = true;
+}
+
+/** @returns {void} */
+export function script_allMonitorsEnabled() {
+  _allMonitorsEnabled = true;
+}
+
+/** @returns {void} */
+export function script_alwaysAutoHideIndependent() {
+  _alwaysAutoHideIndependent = true;
+}
+
+/** @returns {void} */
 export function finish() {
   if (!_dockPresent)
     throw new Error('Dock actor was not found in the stage after extension enable');
@@ -836,5 +953,11 @@ export function finish() {
     throw new Error('Automatic icon resize did not account for fixed dock icons');
   if (!_externalWorkspaceActorStable)
     throw new Error('External-monitor Dock actor did not remain stable in workspace two');
+  if (!_primaryMonitorOnly)
+    throw new Error('Dock primary-monitor-only behavior was not verified');
+  if (!_allMonitorsEnabled)
+    throw new Error('Dock all-monitors opt-in behavior was not verified');
+  if (!_alwaysAutoHideIndependent)
+    throw new Error('Dock always auto-hide behavior was not verified');
   if (!_dockRemoved) throw new Error('Dock actor was not removed after module was disabled');
 }

--- a/tests/unit/monitorTopology.test.ts
+++ b/tests/unit/monitorTopology.test.ts
@@ -8,7 +8,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { hasDefinedBottom } from '../../src/dock/monitorTopology.ts';
+import { getDockMonitorIndexes, hasDefinedBottom } from '../../src/dock/monitorTopology.ts';
 
 const mon = (x: number, y: number, width: number, height: number) => ({
   x,
@@ -49,4 +49,33 @@ test('hasDefinedBottom — out-of-bounds index returns false', () => {
   const monitors = [mon(0, 0, 1920, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, -1), false);
   assert.strictEqual(hasDefinedBottom(monitors, 5), false);
+});
+
+test('getDockMonitorIndexes — primary-only mode selects only the primary monitor', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  assert.deepEqual(getDockMonitorIndexes(monitors, 1, false), [1]);
+});
+
+test('getDockMonitorIndexes — primary-only mode follows a changed primary monitor', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  assert.deepEqual(getDockMonitorIndexes(monitors, 0, false), [0]);
+  assert.deepEqual(getDockMonitorIndexes(monitors, 1, false), [1]);
+});
+
+test('getDockMonitorIndexes — primary-only mode keeps a primary with a monitor below it', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(0, 1080, 1920, 1080)];
+  assert.deepEqual(getDockMonitorIndexes(monitors, 0, false), [0]);
+});
+
+test('getDockMonitorIndexes — all-monitors mode excludes internal bottom edges', () => {
+  const monitors = [
+    mon(0, 0, 1920, 1080),
+    mon(0, 1080, 1920, 1080),
+    mon(1920, 0, 1920, 1080),
+  ];
+  assert.deepEqual(getDockMonitorIndexes(monitors, 0, true), [1, 2]);
+});
+
+test('getDockMonitorIndexes — invalid primary produces no dock in primary-only mode', () => {
+  assert.deepEqual(getDockMonitorIndexes([mon(0, 0, 1920, 1080)], -1, false), []);
 });

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -224,3 +224,11 @@ test('schema — Vela Shell fallback is disabled by default', () => {
 test('schema — Clipboard History automatic paste is enabled by default', () => {
   assert.equal(schemaDefault('clipboard-history-auto-paste'), 'true');
 });
+
+test('schema — Dock defaults to the primary monitor only', () => {
+  assert.equal(schemaDefault('dock-show-on-all-monitors'), 'false');
+});
+
+test('schema — Dock always auto-hide is disabled by default', () => {
+  assert.equal(schemaDefault('dock-always-autohide'), 'false');
+});


### PR DESCRIPTION
- Introduced 'dock-always-autohide' setting to keep the dock hidden until the pointer reaches the screen edge.
- Added 'dock-show-on-all-monitors' setting to allow the dock to be displayed on all eligible monitors.
- Updated dock behavior to manage visibility based on the new settings.
- Enhanced the dock's development tool to reflect the new auto-hide feature.
- Implemented tests for the new dock settings and their default values.

This implements the request #69 