### PR TITLE
ci: publish release candidates manually via workflow_dispatch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,8 +1,6 @@
 name: Nightly pre-release
 
 on:
-  schedule:
-    - cron: '15 0 * * *'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,23 +4,47 @@ on:
   push:
     tags:
       - 'v[0-9]*'
+      - '!v[0-9]*-rc*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release candidate tag to publish (e.g. v49.0-rc1)
+        required: true
+        type: string
 
 permissions:
   contents: write
   packages: write
 
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
 jobs:
   ci:
-    if: ${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/ci.yml
+    with:
+      checkout_ref: ${{ inputs.tag || '' }}
 
   release:
     name: Create GitHub Release
-    if: ${{ !contains(github.ref_name, '-') || contains(github.ref_name, '-rc') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     needs: [ci]
     steps:
+      - name: Validate release candidate tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag }}"
+          if [[ "$tag" != *-rc* ]]; then
+            echo "Tag '$tag' is not a release candidate (expected to contain '-rc')." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || '' }}
 
       - name: Download extension zip
         uses: actions/download-artifact@v8
@@ -31,15 +55,16 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_TAG }}
           files: dist/target/aurora-shell@luminusos.github.io.shell-extension.zip
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create maintenance branch
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: ${{ github.event_name == 'push' }}
         run: |
-          MAJOR=$(echo "${{ github.ref_name }}" | sed 's/^v//' | grep -oP '^\d+')
+          MAJOR=$(echo "${{ env.RELEASE_TAG }}" | sed 's/^v//' | grep -oP '^\d+')
           BRANCH="release/v${MAJOR}.x"
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
             echo "Branch $BRANCH already exists, skipping."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thank you for your interest in contributing to Aurora Shell! This document outlines the project architecture and provides guidelines for adding new modules and adhering to the project's code style.
 
+## AI-Assisted Contributions
+
+Contributions made with AI assistance are welcome, but the contributor remains
+responsible for the change. Do not submit code you do not understand. You must
+be able to explain what the code does, why it is correct, and what tradeoffs or
+risks it introduces.
+
+AI-assisted changes must be tested thoroughly. Maintainers may ask for evidence
+that the functionality works and was tested, such as test output, screenshots,
+screen recordings, logs, or clear reproduction steps.
+
 ## Architecture Overview
 
 Aurora Shell keeps GNOME integration close to each functional area. `extension.ts` creates the
@@ -90,7 +101,9 @@ and adds a final version bump commit. For example, if `metadata.json` on `releas
 
 ### Release candidates
 
-Release candidates are published alongside GNOME Shell RCs. Tags follow the pattern `v50-rc1`, `v50-rc2`, etc. RC releases are automatically marked as **pre-releases** on GitHub.
+Release candidates are published alongside GNOME Shell RCs. Tags follow the pattern `v50-rc1`, `v50-rc2`, etc. RC releases are marked as **pre-releases** on GitHub.
+
+Pushing an RC tag does **not** publish anything. After pushing the tag, trigger the `Release` workflow manually (`workflow_dispatch`) and pass the tag name in the `tag` input. The workflow validates that the tag contains `-rc`, runs CI against it, and publishes the pre-release.
 
 ### Stable releases
 
@@ -176,7 +189,7 @@ D-Bus services.
 
 All jobs must pass before a PR can be merged.
 
-When a version tag (`v50.1`, `v50-rc1`, etc.) is pushed, `.github/workflows/release.yml` calls the CI pipeline and, if all jobs pass, publishes the GitHub Release automatically.
+When a stable version tag (`v50.1`, `v50.2`, etc.) is pushed, `.github/workflows/release.yml` calls the CI pipeline and, if all jobs pass, publishes the GitHub Release automatically. Release candidate tags (`v50-rc1`, etc.) are excluded from this trigger and are published manually via `workflow_dispatch`, as described above.
 
 ## Coding Standards
 


### PR DESCRIPTION
## Summary

- **RC tags no longer auto-publish.** Pushing a `v*-rc*` tag does nothing; the `Release` workflow gains a `workflow_dispatch` trigger that takes the RC tag as input, validates the `-rc` suffix, runs CI against that tag (via `checkout_ref`), and publishes it as a GitHub pre-release. Stable tag pushes keep the fully automatic flow.
- **Nightly pre-release schedule paused.** The cron trigger is removed; nightly stays available via `workflow_dispatch`.
- **AI-assisted contributions policy** added to `CONTRIBUTING.md`, mirroring the images repo.
