### PR TITLE
fix(vpn): disable Vela integration by default

### DIFF
--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -93,7 +93,7 @@
       <description>Shows app name tooltip on hover in the overview search results</description>
     </key>
     <key name="module-vela-vpn-quick-settings" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Enable Vela VPN Quick Settings module</summary>
       <description>Routes VPN Quick Settings activation through Vela</description>
     </key>

--- a/tests/shell/auroraVelaVpnQuickSettings.js
+++ b/tests/shell/auroraVelaVpnQuickSettings.js
@@ -21,7 +21,7 @@ export var METRICS = {};
 export function init() {
   Scripting.defineScriptEvent(
     'fallbackPolicyOk',
-    'Vela VPN fallback is opt-in and handles ServiceUnknown',
+    'Vela VPN integration is opt-in and handles ServiceUnknown fallback',
   );
 }
 
@@ -33,8 +33,12 @@ export async function run() {
   const originalFallbackEnabled = settings.get_boolean(FALLBACK_SETTING);
 
   try {
-    const defaultValue = settings.get_default_value(FALLBACK_SETTING)?.unpack();
-    if (defaultValue !== false)
+    const defaultModuleEnabled = settings.get_default_value(MODULE_SETTING)?.unpack();
+    if (defaultModuleEnabled !== false)
+      throw new Error('Vela VPN integration must be disabled by default');
+
+    const defaultFallbackEnabled = settings.get_default_value(FALLBACK_SETTING)?.unpack();
+    if (defaultFallbackEnabled !== false)
       throw new Error('Vela VPN Shell fallback must be disabled by default');
 
     settings.set_boolean(MODULE_SETTING, true);

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -217,7 +217,8 @@ test('schema ↔ catalog — every declared module and option setting is synchro
   assert.deepEqual([...compiledSchemaKeys()].sort(), [...catalogSettingsKeys()].sort());
 });
 
-test('schema — Vela Shell fallback is disabled by default', () => {
+test('schema — Vela VPN integration and Shell fallback are disabled by default', () => {
+  assert.equal(schemaDefault('module-vela-vpn-quick-settings'), 'false');
   assert.equal(schemaDefault('vela-vpn-quick-settings-shell-fallback'), 'false');
 });
 


### PR DESCRIPTION
Keep both the Vela VPN Quick Settings module and its GNOME Shell fallback opt-in so a fresh Aurora installation does not intercept VPN activation unless the user explicitly enables the integration.

Retain integration coverage for the enabled path and ServiceUnknown fallback while asserting both disabled schema defaults in unit and GNOME Shell tests.