### PR TITLE
feat(capture): improve screenshot integration

### DIFF
--- a/src/capture/captureToolbarPositioner.ts
+++ b/src/capture/captureToolbarPositioner.ts
@@ -115,9 +115,16 @@ export class CaptureToolbarPositioner {
     }
 
     const [stageX, stageY] = this._toolbar.get_transformed_position();
+    const panelExtents = this._ui._panel.get_transformed_extents();
     const translation = calculateToolbarTranslation({
       monitor,
       selection: selectionRectangle,
+      protectedArea: {
+        x: panelExtents.get_x(),
+        y: panelExtents.get_y(),
+        width: panelExtents.get_width(),
+        height: panelExtents.get_height(),
+      },
       toolbar: {
         width: this._toolbar.width,
         height: this._toolbar.height,

--- a/src/capture/captureTools.ts
+++ b/src/capture/captureTools.ts
@@ -162,6 +162,9 @@ export class CaptureTools extends Module {
     for (const button of [ui._shotButton, ui._castButton]) {
       scope.connect(button, 'notify::checked', () => this._syncVisibility());
     }
+    scope.connect(ui._castButton, 'notify::checked', () => {
+      if (ui._castButton.checked) ui._showPointerButton.checked = true;
+    });
 
     for (const button of [ui._selectionButton, ui._screenButton, ui._windowButton]) {
       scope.connect(button, 'notify::checked', () => ocr.clear());

--- a/src/capture/toolbarPlacement.ts
+++ b/src/capture/toolbarPlacement.ts
@@ -3,6 +3,7 @@ export type Rectangle = { x: number; y: number; width: number; height: number };
 export type ToolbarPlacement = {
   monitor: Rectangle;
   selection: Rectangle;
+  protectedArea?: Rectangle;
   toolbar: {
     width: number;
     height: number;
@@ -52,7 +53,7 @@ export function findMonitorForSelection(
 export function calculateToolbarTranslation(
   placement: ToolbarPlacement,
 ): ToolbarTranslation | null {
-  const { monitor, selection, toolbar, margin } = placement;
+  const { monitor, selection, protectedArea, toolbar, margin } = placement;
   const coordinates = [
     monitor.x,
     monitor.y,
@@ -80,6 +81,7 @@ export function calculateToolbarTranslation(
     toolbar.height <= 0
   )
     return null;
+  if (protectedArea && !isValidRectangle(protectedArea)) return null;
 
   const anchorX = toolbar.stageX - toolbar.translationX;
   const anchorY = toolbar.stageY - toolbar.translationY;
@@ -94,11 +96,50 @@ export function calculateToolbarTranslation(
   if (desiredY < monitor.y) desiredY = selection.y + selection.height + margin;
   desiredY = Math.max(monitor.y, Math.min(desiredY, monitor.y + monitor.height - toolbar.height));
 
+  if (
+    protectedArea &&
+    rectanglesOverlap(
+      { x: desiredX, y: desiredY, width: toolbar.width, height: toolbar.height },
+      protectedArea,
+    )
+  ) {
+    const candidates = [
+      protectedArea.y - toolbar.height - margin,
+      protectedArea.y + protectedArea.height + margin,
+    ].filter((candidateY) => {
+      const toolbarRectangle = {
+        x: desiredX,
+        y: candidateY,
+        width: toolbar.width,
+        height: toolbar.height,
+      };
+      return (
+        candidateY >= monitor.y &&
+        candidateY + toolbar.height <= monitor.y + monitor.height &&
+        !rectanglesOverlap(toolbarRectangle, protectedArea)
+      );
+    });
+
+    if (candidates.length > 0) {
+      candidates.sort((first, second) => Math.abs(first - desiredY) - Math.abs(second - desiredY));
+      desiredY = candidates[0]!;
+    }
+  }
+
   const translation = {
     x: Math.round(desiredX - anchorX),
     y: Math.round(desiredY - anchorY),
   };
   return Number.isFinite(translation.x) && Number.isFinite(translation.y) ? translation : null;
+}
+
+function rectanglesOverlap(first: Rectangle, second: Rectangle): boolean {
+  return (
+    first.x < second.x + second.width &&
+    first.x + first.width > second.x &&
+    first.y < second.y + second.height &&
+    first.y + first.height > second.y
+  );
 }
 
 function isValidRectangle(rectangle: Rectangle): boolean {

--- a/tests/shell/auroraCaptureTools.js
+++ b/tests/shell/auroraCaptureTools.js
@@ -35,6 +35,17 @@ function resolvedIconPath(button) {
   return path;
 }
 
+function actorsOverlap(first, second) {
+  const firstBox = first.get_transformed_extents();
+  const secondBox = second.get_transformed_extents();
+  return (
+    firstBox.get_x() < secondBox.get_x() + secondBox.get_width() &&
+    firstBox.get_x() + firstBox.get_width() > secondBox.get_x() &&
+    firstBox.get_y() < secondBox.get_y() + secondBox.get_height() &&
+    firstBox.get_y() + firstBox.get_height() > secondBox.get_y()
+  );
+}
+
 export var METRICS = {};
 
 export function init() {
@@ -43,6 +54,14 @@ export function init() {
   Scripting.defineScriptEvent(
     'externalMonitorPlacement',
     'Floating toolbar follows a selection onto an external monitor',
+  );
+  Scripting.defineScriptEvent(
+    'nativeControlsAvoided',
+    'Floating toolbar avoids the native screenshot controls',
+  );
+  Scripting.defineScriptEvent(
+    'recordingPointerEnabled',
+    'Screen recording enables pointer capture automatically',
   );
   Scripting.defineScriptEvent('drawingMode', 'Drawing tool activates the capture canvas');
   Scripting.defineScriptEvent(
@@ -147,6 +166,42 @@ export async function run() {
     throw new Error('Capture toolbar produced a non-finite translation');
   if (!toolbar.has_style_class_name('screenshot-ui-panel'))
     throw new Error('Capture toolbar does not use the native screenshot panel styling');
+
+  ui._showPointerButton.checked = false;
+  ui._castButton.checked = true;
+  await Scripting.sleep(50);
+  if (!ui._showPointerButton.checked)
+    throw new Error('Record Screen did not enable pointer capture automatically');
+  ui._shotButton.checked = true;
+  await Scripting.sleep(50);
+  Scripting.scriptEvent('recordingPointerEnabled');
+
+  const primaryMonitor = Main.layoutManager.primaryMonitor;
+  const originalPrimarySelection = [
+    ui._areaSelector._startX,
+    ui._areaSelector._startY,
+    ui._areaSelector._lastX,
+    ui._areaSelector._lastY,
+  ];
+  ui._areaSelector._startX = primaryMonitor.x + 1;
+  ui._areaSelector._startY = primaryMonitor.y + 1;
+  ui._areaSelector._lastX = primaryMonitor.x + primaryMonitor.width - 1;
+  ui._areaSelector._lastY = primaryMonitor.y + primaryMonitor.height - 1;
+  ui._areaSelector._updateSelectionRect();
+  ui._areaSelector.emit('drag-ended');
+  await Scripting.sleep(250);
+  if (actorsOverlap(toolbar, ui._panel))
+    throw new Error('Capture toolbar overlaps the native screenshot controls');
+  [
+    ui._areaSelector._startX,
+    ui._areaSelector._startY,
+    ui._areaSelector._lastX,
+    ui._areaSelector._lastY,
+  ] = originalPrimarySelection;
+  ui._areaSelector._updateSelectionRect();
+  ui._areaSelector.emit('drag-ended');
+  await Scripting.sleep(250);
+  Scripting.scriptEvent('nativeControlsAvoided');
 
   const externalMonitor = Main.layoutManager.monitors.find(
     (_monitor, index) => index !== Main.layoutManager.primaryIndex,
@@ -299,6 +354,8 @@ export async function run() {
 let _attachedOnce = false;
 let _visibleOnOpen = false;
 let _externalMonitorPlacement = false;
+let _nativeControlsAvoided = false;
+let _recordingPointerEnabled = false;
 let _drawingMode = false;
 let _lifecycleRestored = false;
 
@@ -314,6 +371,14 @@ export function script_externalMonitorPlacement() {
   _externalMonitorPlacement = true;
 }
 
+export function script_nativeControlsAvoided() {
+  _nativeControlsAvoided = true;
+}
+
+export function script_recordingPointerEnabled() {
+  _recordingPointerEnabled = true;
+}
+
 export function script_drawingMode() {
   _drawingMode = true;
 }
@@ -327,6 +392,10 @@ export function finish() {
   if (!_visibleOnOpen) throw new Error('Immediate toolbar visibility was not verified');
   if (!_externalMonitorPlacement)
     throw new Error('External-monitor toolbar placement was not verified');
+  if (!_nativeControlsAvoided)
+    throw new Error('Native screenshot control avoidance was not verified');
+  if (!_recordingPointerEnabled)
+    throw new Error('Automatic recording pointer selection was not verified');
   if (!_drawingMode) throw new Error('Capture Tools drawing mode was not verified');
   if (!_lifecycleRestored) throw new Error('Capture Tools lifecycle restoration was not verified');
 }

--- a/tests/unit/toolbarPlacement.test.ts
+++ b/tests/unit/toolbarPlacement.test.ts
@@ -35,6 +35,28 @@ test('toolbar placement moves below selections that have no room above', () => {
   );
 });
 
+test('toolbar placement avoids protected native controls', () => {
+  assert.deepEqual(
+    calculateToolbarTranslation({
+      ...placement,
+      selection: { x: 500, y: 10, width: 800, height: 900 },
+      protectedArea: { x: 0, y: 850, width: 1920, height: 200 },
+    }),
+    { x: -60, y: 790 },
+  );
+});
+
+test('toolbar placement ignores a protected area outside its horizontal path', () => {
+  assert.deepEqual(
+    calculateToolbarTranslation({
+      ...placement,
+      selection: { x: 20, y: 10, width: 300, height: 200 },
+      protectedArea: { x: 1400, y: 200, width: 400, height: 200 },
+    }),
+    { x: -660, y: 222 },
+  );
+});
+
 test('toolbar placement selects the monitor containing most of the selection', () => {
   const monitors = [
     { x: 0, y: 0, width: 1920, height: 1080 },


### PR DESCRIPTION
Keep the floating toolbar clear of the native GNOME controls and enable pointer capture when entering screen recording. Add unit and Shell coverage for both behaviors.