### PR TITLE
fix(clipboard): preserve card focus behavior

### DIFF
--- a/src/clipboard/clipboardItem.ts
+++ b/src/clipboard/clipboardItem.ts
@@ -97,9 +97,14 @@ export class ClipboardItem extends St.Button {
   setActionsVisible(visible: boolean): void {
     const showPinnedBadge = !visible && this._entry.pinned;
     this._actions.visible = visible || showPinnedBadge;
+    if (showPinnedBadge) {
+      this._actions.add_style_class_name('pinned-badge');
+    } else {
+      this._actions.remove_style_class_name('pinned-badge');
+    }
 
     this._pinButton.visible = visible || this._entry.pinned;
-    this._pinButton.reactive = visible || showPinnedBadge;
+    this._pinButton.reactive = visible;
     this._pinButton.can_focus = visible;
 
     for (const button of [this._removeButton, this._menuButton]) {

--- a/src/clipboard/clipboardList.ts
+++ b/src/clipboard/clipboardList.ts
@@ -139,6 +139,12 @@ export class ClipboardList extends St.BoxLayout {
       cbs: ListCallbacks,
     ) => ClipboardItem)(entry, this._callbacks);
     item.connect('clicked', () => this._callbacks.onActivate(entry));
+    item.connect('notify::hover', () => {
+      if (!item.hover) return;
+
+      const index = this._items.indexOf(item);
+      if (index >= 0) this._setSelected(index);
+    });
     this._items.push(item);
     this.add_child(item);
   }

--- a/src/styles/_clipboard-history.scss
+++ b/src/styles/_clipboard-history.scss
@@ -5,6 +5,7 @@
 $aurora-clipboard-card-max-height: 84px;
 $aurora-clipboard-card-content-height: 68px;
 $aurora-clipboard-card-image-height: 100px;
+$aurora-clipboard-card-actions-height: 32px;
 
 .aurora-clipboard-panel {
   background-color: vars.$aurora-overview-bg;
@@ -114,6 +115,7 @@ $aurora-clipboard-card-image-height: 100px;
 }
 
 .aurora-clipboard-item-text-overlay {
+  min-height: $aurora-clipboard-card-actions-height;
   max-height: $aurora-clipboard-card-content-height;
 }
 
@@ -174,7 +176,7 @@ $aurora-clipboard-card-image-height: 100px;
 
 .aurora-clipboard-item-code-badge {
   margin: 0 1px 1px 0;
-  padding: 2px 5px;
+  padding: 1px 5px;
   border-radius: 6px;
   font-size: 0.74em;
   background-color: rgba(0, 0, 0, 0.62);
@@ -184,9 +186,14 @@ $aurora-clipboard-card-image-height: 100px;
 
 .aurora-clipboard-item-actions {
   spacing: 4px;
-  padding: 5px;
+  padding: 2px 5px;
   border-radius: 12px;
   background-color: st-mix(vars.$aurora-overview-bg, vars.$aurora-overview-fg, 88%);
+
+  &.pinned-badge {
+    padding: 0;
+    background-color: transparent;
+  }
 }
 
 .aurora-clipboard-item-action {

--- a/tests/shell/auroraClipboardHistory.js
+++ b/tests/shell/auroraClipboardHistory.js
@@ -177,6 +177,10 @@ export function init() {
   Scripting.defineScriptEvent('clipboardImageWritten', 'Clipboard image written for monitor test');
   Scripting.defineScriptEvent('textCardLayoutOk', 'Text card wraps without growing horizontally');
   Scripting.defineScriptEvent('codeBadgeLayoutOk', 'Code line badge does not increase card height');
+  Scripting.defineScriptEvent(
+    'pinnedHoverActionsOk',
+    'Hover reveals actions on history items when a pinned item exists',
+  );
   Scripting.defineScriptEvent('panelOpened', 'Clipboard panel opened inside work area');
   Scripting.defineScriptEvent(
     'autoPasteOk',
@@ -393,7 +397,8 @@ export async function run() {
 
   const textOverlay = findActorByStyle(longItem, 'aurora-clipboard-item-text-overlay');
   const textBody = findActorByStyle(longItem, 'aurora-clipboard-item-text-body');
-  if (!textOverlay || !textBody) {
+  const longTextLabel = findActorByStyle(longItem, 'aurora-clipboard-item-label');
+  if (!textOverlay || !textBody || !longTextLabel) {
     throw new Error('Text card content was not found');
   }
   if (textBody.width !== textOverlay.width) {
@@ -403,11 +408,8 @@ export async function run() {
   }
 
   const widthBeforeSelection = longItem.width;
-  if (longItem.height <= shortItem.height) {
-    throw new Error(
-      `Long text card did not expand vertically: short=${shortItem.height}, long=${longItem.height}`,
-    );
-  }
+  if (longTextLabel.clutter_text.get_layout().get_line_count() <= 1)
+    throw new Error('Long text card did not wrap onto multiple lines');
 
   const longItemIndex = list._items.indexOf(longItem);
   list.moveFocus(longItemIndex);
@@ -437,6 +439,7 @@ export async function run() {
   assertFloatingActions(longItem, 'aurora-clipboard-item-text-overlay');
 
   const shortItemIndex = list._items.indexOf(shortItem);
+  const shortHeightBeforeSelection = shortItem.height;
   list.moveFocus(shortItemIndex - longItemIndex);
   await Scripting.waitLeisure();
   await Scripting.sleep(100);
@@ -444,6 +447,11 @@ export async function run() {
   const shortActions = findActorByStyle(shortItem, 'aurora-clipboard-item-actions');
   if (!shortOverlay || !shortActions) {
     throw new Error('Short text card actions were not found');
+  }
+  if (shortItem.height !== shortHeightBeforeSelection) {
+    throw new Error(
+      `Short text card height changed on focus: before=${shortHeightBeforeSelection}, after=${shortItem.height}`,
+    );
   }
   if (shortActions.y + shortActions.height > shortOverlay.height) {
     throw new Error(
@@ -483,6 +491,57 @@ export async function run() {
     );
   }
   Scripting.scriptEvent('codeBadgeLayoutOk');
+
+  clipboardModule._onTogglePin(shortItem.entry.id);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(100);
+  const refreshedList = panel._list;
+  const pinnedItem = refreshedList._items.find(
+    (item) => item.entry.text === 'Short clipboard entry',
+  );
+  const hoveredHistoryItem = refreshedList._items.find((item) => item.entry.text === longText);
+  if (!pinnedItem?.entry.pinned || !hoveredHistoryItem || hoveredHistoryItem.entry.pinned) {
+    throw new Error('Could not prepare pinned and history items for the hover actions test');
+  }
+  hoveredHistoryItem.set_hover(true);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(100);
+  if (
+    refreshedList.selectedItem !== hoveredHistoryItem ||
+    !hoveredHistoryItem._removeButton.visible ||
+    !hoveredHistoryItem._menuButton.visible
+  ) {
+    throw new Error('Hover did not reveal actions on a history item beside a pinned item');
+  }
+  if (
+    !pinnedItem._actions.has_style_class_name('pinned-badge') ||
+    pinnedItem._pinButton.reactive ||
+    pinnedItem._pinButton.can_focus
+  ) {
+    throw new Error('Inactive pinned item did not become a passive borderless badge');
+  }
+  const pinnedActionsTheme = pinnedItem._actions.get_theme_node();
+  const pinnedActionsBackground = pinnedActionsTheme.get_background_color();
+  if (
+    pinnedActionsBackground.alpha !== 0 ||
+    [St.Side.TOP, St.Side.RIGHT, St.Side.BOTTOM, St.Side.LEFT].some(
+      (side) => pinnedActionsTheme.get_padding(side) !== 0,
+    )
+  ) {
+    throw new Error('Inactive pinned badge retained the action container background or padding');
+  }
+  const pinnedHeightBeforeFocus = pinnedItem.height;
+  pinnedItem.set_hover(true);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(100);
+  if (pinnedItem.height !== pinnedHeightBeforeFocus) {
+    throw new Error(
+      `Pinned short card height changed on focus: before=${pinnedHeightBeforeFocus}, after=${pinnedItem.height}`,
+    );
+  }
+  pinnedItem.set_hover(false);
+  hoveredHistoryItem.set_hover(false);
+  Scripting.scriptEvent('pinnedHoverActionsOk');
 
   let targetActivationCount = 0;
   const pasteProbe = new St.Entry({ can_focus: true });
@@ -570,6 +629,7 @@ let _clipboardWritten = false;
 let _clipboardImageWritten = false;
 let _textCardLayoutOk = false;
 let _codeBadgeLayoutOk = false;
+let _pinnedHoverActionsOk = false;
 let _panelOpened = false;
 let _autoPasteOk = false;
 let _workspacePanelOk = false;
@@ -596,6 +656,9 @@ export function script_textCardLayoutOk() {
 export function script_codeBadgeLayoutOk() {
   _codeBadgeLayoutOk = true;
 }
+export function script_pinnedHoverActionsOk() {
+  _pinnedHoverActionsOk = true;
+}
 export function script_panelOpened() {
   _panelOpened = true;
 }
@@ -616,6 +679,8 @@ export function finish() {
   if (!_clipboardImageWritten) throw new Error('Clipboard image write step did not complete');
   if (!_textCardLayoutOk) throw new Error('Clipboard text card layout check did not complete');
   if (!_codeBadgeLayoutOk) throw new Error('Clipboard code badge layout check did not complete');
+  if (!_pinnedHoverActionsOk)
+    throw new Error('Clipboard pinned-item hover actions check did not complete');
   if (!_panelOpened) throw new Error('Clipboard panel did not open inside the work area');
   if (!_autoPasteOk) throw new Error('Clipboard automatic paste check did not complete');
   if (!_workspacePanelOk) throw new Error('Clipboard workspace visibility check did not complete');


### PR DESCRIPTION
Reveal actions when hover moves away from a pinned item, render inactive pins as passive badges, and keep short cards at a stable height. Extend the Shell test to cover pinned and regular cards.