### PR TITLE
docs(contributing): organize project documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Thumbs.db
 # Vagrant
 .vagrant/
 .docs/
-docs/
+docs/superpowers/
 .superpowers/
 
 # IA Stuff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Apply these rules during implementation and review:
   separate application. If a subprocess is unavoidable, document why D-Bus is not practical and keep
   invocation local, explicit, cancellable, and free of shell interpretation.
 - Review every Shexli finding. Fix real ownership/lifecycle defects and record accepted manual-review
-  findings or analyzer false positives in `EGO_REVIEW.md`.
+  findings or analyzer false positives in `docs/extension-review.md`.
 
 - Never use patterns like `this.disconnectObject?.(this)` on objects that do not own that signal
   connection contract.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,231 +1,91 @@
 # Contributing to Aurora Shell
 
-Thank you for your interest in contributing to Aurora Shell! This document outlines the project architecture and provides guidelines for adding new modules and adhering to the project's code style.
+Thank you for contributing to Aurora Shell. Keep changes focused, test the behavior they affect,
+and make the intent easy to understand in review.
 
-## AI-Assisted Contributions
+## Before You Start
 
-Contributions made with AI assistance are welcome, but the contributor remains
-responsible for the change. Do not submit code you do not understand. You must
-be able to explain what the code does, why it is correct, and what tradeoffs or
-risks it introduces.
+- Branch from the latest `main`.
+- Keep each pull request limited to one feature, fix, or refactor.
+- Add regression coverage for bug fixes and tests for new behavior.
+- Read the [documentation index](docs/README.md) for architecture and development guidance.
 
-AI-assisted changes must be tested thoroughly. Maintainers may ask for evidence
-that the functionality works and was tested, such as test output, screenshots,
-screen recordings, logs, or clear reproduction steps.
+## Commit Messages
 
-## Architecture Overview
+Use [Conventional Commits](https://www.conventionalcommits.org/) for the subject and breaking-change
+notation:
 
-Aurora Shell keeps GNOME integration close to each functional area. `extension.ts` creates the
-context and delegates module lifecycle to `ModuleManager`. The ordered `moduleCatalog.ts` is shared by
-runtime and preferences; `registry.ts` only associates each manifest with its implementation factory.
-
-Module descriptions live in Shell-free `*.manifest.ts` files. Implementations contain behavior and
-lifecycle only. Pure calculations should be extracted when they are independently testable, while direct
-`Main`/St/Clutter integration remains idiomatic for a GNOME Shell extension.
-
-## Adding a Module
-
-1. Create `feature.manifest.ts` and the `Module` implementation in the appropriate functional area.
-2. Add the manifest to `moduleCatalog.ts` in preference order.
-3. Associate the manifest key with its factory in `registry.ts`.
-4. Add every module, option, and internal setting key to the GSettings schema.
-5. Add unit coverage for pure logic and a Shell test for GNOME integration.
-
-A minimal manifest looks like:
-
-```typescript
-import { gettext as _ } from 'gettext';
-import type { ModuleManifest } from '~/module.ts';
-
-export const manifest: ModuleManifest = {
-  key: 'my-module',
-  settingsKey: 'module-my-module',
-  section: 'behavior',
-  title: _('My Module'),
-  subtitle: _('Description'),
-  runtime: { roles: ['desktop'], scope: 'session' },
-  options: [{ key: 'my-option', title: _('Option'), subtitle: _('Description'), type: 'switch' }],
-};
+```text
+<type>[optional scope][!]: <description>
 ```
 
-The runtime implementation keeps the small `enable()`/`disable()` contract. Use
-a fresh `LifecycleScope` to own signal connections and register teardown callbacks for each
-enable/disable cycle; keep timers, D-Bus subscriptions, and other stateful GNOME APIs explicit at
-their call sites.
+- Use a standard type such as `feat`, `fix`, `docs`, `refactor`, `test`, `build`, `ci`, or `chore`.
+- Add a short scope when it helps identify the affected area.
+- Write the description in imperative present tense: `fix(clipboard): preserve card height`, not
+  `fixed` or `fixes`.
+- Keep the complete subject under 72 characters and omit the trailing period.
+- Mark a breaking change with `!` before the colon and explain it in a `BREAKING CHANGE:` footer.
 
-`tests/unit/registry.test.ts` verifies catalog order, uniqueness, known sections, and factory
-coverage through the TypeScript AST. `tests/unit/schema.test.ts` structurally validates XML and
-requires catalog settings and schema keys to match exactly.
+Follow the Chromium Embedded Framework writing style for the remaining message:
 
-## Branching & Release Model
+- Separate the subject, optional body, and optional footers with blank lines.
+- Use the body to explain motivation, behavior, and non-obvious tradeoffs.
+- Keep every commit focused on one concern so it can be reviewed or reverted independently.
 
-Aurora Shell follows a branching model aligned with GNOME Shell's own release cycle.
+For example:
 
-### Branches
+```text
+fix(clipboard): preserve card focus behavior
 
-| Branch          | Purpose                                             |
-| --------------- | --------------------------------------------------- |
-| `main`          | Active development targeting the next GNOME release |
-| `release/v50.x` | Maintenance branch for GNOME 50                     |
-| `release/v51.x` | Maintenance branch for GNOME 51                     |
-
-Maintenance branches are created automatically when the first tag for a new major version is pushed.
-
-### New features
-
-Each major Aurora Shell release targets a single GNOME Shell version. New features land on `main` and are released alongside a new major GNOME Shell version.
-
-Branches targeting already-released GNOME Shell versions are in maintenance mode. **Do not add new features to maintenance branches** — they are strictly for bug fixes and compatibility updates.
-
-### Bug fixes
-
-Bug fixes should target `main` first via a normal PR. If the fix is relevant to a maintenance release, open a **separate PR targeting that branch**:
-
-```bash
-git checkout release/v50.x
-git cherry-pick <commit-sha>
-# open a PR targeting release/v50.x
+Reveal card actions when hover moves away from a pinned item and keep short
+cards at a stable height. Add Shell coverage for both cases.
 ```
 
-Maintainers decide which fixes are worth backporting. Not every fix needs to land in every maintenance branch.
+A breaking change uses both Conventional Commits markers:
 
-### Automated backports
+```text
+feat(settings)!: replace the legacy module keys
 
-To request a maintenance backport, add a label such as `GNOME 50` to the original pull request.
-After the original pull request is merged into `main`, GitHub Actions creates or updates a separate
-backport PR targeting `release/v50.x`.
+Move module configuration to the manifest-backed key format.
 
-The backport branch is rebuilt from the target release branch, cherry-picks the original PR commits,
-and adds a final version bump commit. For example, if `metadata.json` on `release/v50.x` says
-`50.7`, the generated backport PR bumps it to `50.8`.
-
-### Release candidates
-
-Release candidates are published alongside GNOME Shell RCs. Tags follow the pattern `v50-rc1`, `v50-rc2`, etc. RC releases are marked as **pre-releases** on GitHub.
-
-To publish an RC, trigger the `Release` workflow manually (`workflow_dispatch`) — no input is needed. Like the nightly flow, the workflow numbers the next candidate automatically (`v50-rc1`, then `v50-rc2`, ...), tags current `main`, runs CI against it, and publishes the pre-release. An RC supersedes the nightly line, so publishing one deletes all nightly pre-releases.
-
-Every RC and nightly pre-release publishes both the production ZIP and the separate DevTool-enabled
-development ZIP. The production package is the installable artifact for regular users; the
-development package is intended only for contributors, QA, and development sessions.
-
-### Stable releases
-
-Stable releases use tags like `v50.1`, `v50.2`, matching the GNOME Shell major version they target.
-
-To publish a release, create an annotated tag and push it:
-
-```bash
-git tag -a v50.1 -m "Release v50.1"
-git push origin v50.1
+BREAKING CHANGE: Existing custom module keys must be migrated.
 ```
 
-The CI pipeline runs all tests and, if they pass, publishes the GitHub Release automatically with
-both the production ZIP and the separate DevTool-enabled development ZIP.
+## Validate Your Change
 
-## Build System & Commands
-
-- **Install deps:** `just deps` — runs an immutable Yarn install; use once or after changing branches
-- **Build:** `just build` — compiles TypeScript and SCSS, copies metadata/schemas, compiles `.mo` files
-- **Package:** `just package production` — packs the production extension ZIP
-- **Development package:** `just package development` — packs the separate DevTool-enabled ZIP
-- **Package policy:** `just package check` — builds and inspects both artifacts
-- **Install:** `just install` — packages and installs the DevTool-enabled development ZIP
-- **Uninstall:** `just uninstall` — disables and removes the extension
-- **Run (host):** `just run` — installs development and launches a DevTool-enabled devkit session
-- **Validate:** `just validate` — runs tsc, ESLint, Prettier check, and Stylelint
-- **Lint:** `just lint` — runs ESLint only
-- **Unit tests:** `just test unit` — runs unit tests with Node's test runner (no GNOME Shell required)
-- **Coverage:** `just test coverage` — runs unit tests with coverage report
-- **Single integration test:** `just test shell <script>` — packages and runs one shell test headlessly
-- **All integration tests:** `just test all` — packages and runs all shell tests on the host, printing a pass/fail summary
-- **DevTool integration test:** `just test dev` — runs the DevTool test against the development ZIP
-- **Shexli review scan:** `just shexli` — packages the extension and runs the extensions.gnome.org static analyzer on the generated ZIP
-- **Watch SCSS:** `just watch` — watches `src/styles/` and recompiles on change
-- **View logs:** `just logs` — shows recent `aurora` entries from the current boot journal
-- **Clean:** `just clean` — removes `dist/`
-- **Deep clean:** `just clean all` — removes `dist/` and `node_modules/`
-
-For a full test environment, create the Fedora toolbox with `just toolbox create` and run
-`just toolbox test all` (preferred over `just test all`). The toolbox uses the public,
-versioned GNOME image from `ghcr.io/luminusos/aurora-shell-ci` shared with CI. Set
-`AURORA_TOOLBOX_IMAGE` to test a locally built replacement.
-
-The image is defined by `Containerfile`; its tag is derived from the first `shell-version` in
-`metadata.json` and a hash of the container inputs. CI publishes a missing tag automatically for
-amd64 and arm64. The GHCR package must remain public so forked pull requests and Toolbox can pull it
-without repository credentials. Set `AURORA_TOOLBOX_NAME` when maintaining more than one Aurora
-development toolbox. `Vagrantfile` remains available for manual testing against other GNOME
-environments.
-
-The first CI job derives a content-addressed tag from the GNOME metadata and container inputs. If
-that tag does not exist, the job builds and publishes it to GHCR for amd64 and arm64; all remaining
-jobs then run directly inside that exact image. No local-build fallback or separate image workflow
-is involved.
-
-To advance to a new GNOME generation, update `metadata.json`, the GNOME type dependencies, and the
-single `FEDORA_VERSION` argument in `Containerfile`. Those changes produce a new image tag, which CI
-publishes before starting validation and tests; Toolbox resolves the same tag automatically.
-
-## GNOME Extensions Review
-
-Aurora Shell can be checked locally with Shexli, the experimental static analyzer used by
-extensions.gnome.org:
+For source changes, run the standard checks:
 
 ```bash
+just validate
+just test unit
 just shexli
 ```
 
-The recipe depends on `just package production` and scans the generated
-`dist/target/aurora-shell@luminusos.github.io.shell-extension.zip`. Install Shexli with
-`python3 -m pip install --user shexli`, or install `uvx` and the recipe will run
-`uvx --from shexli shexli` automatically.
+Run the relevant Shell integration test for a feature-level change. Use
+`just toolbox test all` for architectural or cross-cutting work. See
+[Development and testing](docs/development.md) for the complete command reference and environment
+details.
 
-## CI
+## Pull Requests
 
-Every pull request and release runs the CI pipeline defined in `.github/workflows/ci.yml`. Its first
-job ensures the CI image exists; the four validation jobs then run inside that same image:
+Describe the problem, the chosen solution, and how you validated it. Include screenshots, screen
+recordings, logs, or reproduction steps when they make user-visible or Shell behavior easier to
+review. All CI jobs must pass before merge.
 
-1. **Validate** — runs tsc, ESLint, Prettier check, and Stylelint via `just validate`
-2. **Unit & regression tests** — runs the Node test suite without GNOME Shell
-3. **Build** — runs `just package check` and uploads both extension ZIPs as artifacts (depends on lint)
-4. **Integration tests** — runs the shared Shell-test runner against headless GNOME Shell (depends on build + unit tests)
+Bug fixes target `main` first. Maintenance backports use separate pull requests; see
+[Releases and backports](docs/releases.md).
 
-The private `XDG_RUNTIME_DIR`, system D-Bus, and logind mock in the integration job belong only to
-the isolated headless runtime. Toolbox does not replace the host XDG directories or install fake
-D-Bus services.
+## AI-Assisted Contributions
 
-All jobs must pass before a PR can be merged.
+AI-assisted contributions are welcome, but the contributor remains responsible for every change.
+Do not submit code you do not understand. You must be able to explain why it is correct, what risks
+it introduces, and how it was tested.
 
-When a stable version tag (`v50.1`, `v50.2`, etc.) is pushed, `.github/workflows/release.yml` calls
-the CI pipeline and, if all jobs pass, publishes the GitHub Release automatically with both extension
-ZIPs. Release candidate tags (`v50-rc1`, etc.) are excluded from this trigger and are published
-manually via `workflow_dispatch`, as described above. The nightly workflow follows the same
-two-package release-asset policy.
+## Further Reading
 
-## Coding Standards
-
-- **File names:** `camelCase.ts`
-- **Classes:** `PascalCase`
-- **Private members:** `_prefixed`
-- **Constants:** `UPPER_CASE`
-- **Symmetry:** Everything connected in `enable()` **must** be disconnected or destroyed in `disable()`.
-- **Dependency Injection:** Strictly follow DI; do not reach out to globals.
-
-## Logging Style
-
-Always prefix log messages with the module name in `[PascalCase]` brackets. Use the global `logger` from `~/core/logger.ts` for all logging — do not call `console.log/warn` or `GLib.log_structured` directly from module code.
-
-```typescript
-import { logger } from '~/core/logger.ts';
-
-// Correct
-logger.log('[AuroraTray] Item added: ' + id);
-logger.warn('[IconWeave] No match found for ' + wmClass);
-
-// Wrong — redundant prefix, wrong casing, or bypasses logger
-logger.log('[Aurora Shell] [aurora-tray] Item added: ' + id);
-console.warn('[aurora-shell] Something failed');
-```
-
-The `[Aurora Shell]` prefix is redundant: the SYSLOG_IDENTIFIER in structured logs already routes output to the right extension in the journal.
+- [Documentation index](docs/README.md)
+- [Architecture](docs/architecture.md)
+- [Development and testing](docs/development.md)
+- [Adding and maintaining modules](docs/modules.md)
+- [Releases and backports](docs/releases.md)
+- [GNOME Extensions review notes](docs/extension-review.md)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Do not use the development package as a regular desktop installation.
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for information on project architecture, code style, and step-by-step instructions on how to add a new module.
+We welcome contributions. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and commit
+conventions, then use the [documentation index](docs/README.md) for architecture, development,
+module, and release guidance.
 
 ## Credits & Acknowledgements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Aurora Shell Documentation
+
+This directory contains detailed project guidance. The repository root keeps only the entry points
+and files required by GitHub, contributors, or packaging.
+
+## Project Design
+
+- [Architecture](architecture.md) describes the runtime, source layout, and test boundaries.
+- [GNOME Shell adapter decision](gnome-shell-adapter.md) records why modules use Shell APIs
+  directly.
+- [Adding and maintaining modules](modules.md) covers manifests, lifecycle, settings, and coding
+  conventions.
+
+## Development and Delivery
+
+- [Development and testing](development.md) covers setup, builds, validation, integration tests,
+  Toolbox, and CI.
+- [Releases and backports](releases.md) covers maintenance branches, release candidates, stable
+  releases, and automated backports.
+- [Dock autohide input fixes](backports/dock-autohide-input-fixes.md) records the related fixes and
+  validation required for their maintenance backport.
+- [GNOME Extensions review notes](extension-review.md) records the current Shexli findings and
+  review decisions.
+
+Start with the root [contribution guide](../CONTRIBUTING.md) when preparing a change.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Aurora Shell Architecture
+# Architecture
 
 Aurora Shell is a pragmatic modular GNOME Shell extension. Features remain grouped by functional
 area (`dock`, `panel`, `desktop`, `privacy`, `clipboard`, `theme`, `patches`, and `shared`) and use
@@ -76,6 +76,9 @@ and clock presentation.
 
 ## Adding A Module
 
+See [Adding and maintaining modules](modules.md) for the complete manifest, lifecycle, and coding
+guidance.
+
 1. Add `feature.manifest.ts` and the runtime implementation in the appropriate functional area.
 2. Import the manifest into `moduleCatalog.ts` in preference order.
 3. Associate its factory in `registry.ts`.
@@ -90,7 +93,8 @@ to match the schema exactly.
 
 Pure TypeScript logic belongs in `tests/unit`. St/Clutter/Main integration belongs in
 `tests/shell`. Architectural changes are accepted only after `just validate`, `just test unit`,
-`just shexli`, and `just toolbox test all`.
+`just shexli`, and `just toolbox test all`. See [Development and testing](development.md) for the
+full command reference.
 
 ## Packaging
 

--- a/docs/backports/dock-autohide-input-fixes.md
+++ b/docs/backports/dock-autohide-input-fixes.md
@@ -1,0 +1,135 @@
+# Dock autohide input fixes
+
+This note documents two fixes that should be backported together to the current
+stable branch. Both affect the dock when **Always Show Dock** is disabled.
+
+## 1. Hidden dock creates a dead input area
+
+### Symptom
+
+After the dock hides, controls located behind its former bounds cannot be
+clicked until the pointer leaves that area. Text fields near the bottom of a
+window are a common reproduction case.
+
+### Cause
+
+The visible dash was hidden, but its outer `St.Bin` chrome container remained
+allocated and `reactive: true`. The transparent container therefore continued
+winning Clutter actor picking and intercepted events intended for the window
+underneath.
+
+### Fix
+
+Synchronize the container's input state with dock visibility:
+
+- Disable `container.reactive` immediately when `AuroraDash.hide()` starts.
+- Re-enable it before `AuroraDash.show()` starts.
+- Keep the separate 1 px `DockHotArea` actor active so the hidden dock can still
+  be revealed from the monitor edge.
+
+Relevant file:
+
+- `src/shared/ui/dash.ts`
+
+Regression coverage:
+
+- `tests/shell/auroraDock.js` checks that a hidden dock container is not
+  reactive and that showing the dock restores input.
+
+## 2. Intellihide oscillates on external monitors
+
+### Symptom
+
+On some secondary or third monitors connected through HDMI/DisplayPort, pushing
+the pointer against the bottom edge repeatedly opens and closes the dock. The
+dock cannot stay open long enough to interact with it.
+
+### Cause
+
+The 1 px `DockHotArea` actor remained reactive after revealing the dock. At the
+exact bottom pixel it could stay above the dock in Clutter picking, especially
+with non-primary monitor coordinate layouts. The dock consequently did not
+receive hover state. When the 1.5 second reveal timeout expired, the code
+incorrectly concluded that the pointer had left, released the intellihide
+block, hid the dock, and immediately triggered the hot area again.
+
+The timeout also relied primarily on cached stage-coordinate bounds. Those
+bounds are useful as a fallback, but direct actor hover is the stronger signal
+for whether the user is interacting with the revealed dock.
+
+After monitor rotation, GNOME Shell can emit several allocation, work-area, and
+intellihide updates while the monitor topology settles. Each update requested
+`show(true)`, and `AuroraDash` restarted every request from its fully hidden
+transform. The dock therefore flashed without actually completing a hide.
+Several Dock call sites also invoked `show(true)` immediately after
+`blockAutoHide(true)`, even though `blockAutoHide()` already performs that
+operation.
+
+The intellihide calculation also checked only the focused window or the final
+window in the actor list. Focus and stacking changes could therefore alternate
+the result even when another window continued overlapping the dock. Workspace
+filtering was applied only to the primary monitor, so secondary-monitor docks
+could remain blocked by windows belonging to another workspace.
+
+### Fix
+
+- Add `DockHotArea.setEnabled()` to control both edge triggering and actor
+  reactivity.
+- Disable the hot area for the duration of a reveal so the dock receives hover
+  events even at the bottommost pixel.
+- Ignore duplicate hot-area triggers while a reveal is already active.
+- Keep the reveal alive while `AuroraDash.pointerInsideDock` is true.
+- Retain the coordinate check as a fallback, with complete X and Y bounds.
+- Keep the reveal active and the hot area disabled throughout the complete
+  hide animation.
+- Poll the dash visibility and recreate the hot area/barrier only after the
+  dash is fully hidden. Re-enabling it when the release timeout expires is too
+  early and causes a new edge trigger during the closing animation.
+- Disable the hot area while the overview is visible.
+- Track the requested visibility target in `AuroraDash`, making repeated
+  requests toward the active target idempotent.
+- Preserve the current transform when a show interrupts an in-progress hide,
+  instead of jumping back to the fully hidden pose.
+- Remove redundant `show(true)` calls after `blockAutoHide(true)`.
+- Evaluate every relevant window and block intellihide when any one overlaps
+  the dock.
+- Apply active-workspace filtering uniformly to every monitor, while retaining
+  windows pinned to all workspaces.
+- Recalculate overlap on `active-workspace-changed` and track allocation
+  changes for every relevant window actor.
+- Emit `status-changed` only for a real state transition, including the initial
+  unknown-to-clear/blocked transition.
+
+Relevant files:
+
+- `src/dock/hotArea.ts`
+- `src/dock/dock.ts`
+- `src/shared/ui/dash.ts`
+
+Regression coverage:
+
+- `tests/shell/auroraDock.js` checks that revealing through the hot area marks
+  the reveal active, makes the hot-area actor non-reactive, and rearms edge
+  detection only after the hide animation completes. It also verifies that
+  repeated show requests start the hidden-to-shown animation only once.
+
+## Backport validation
+
+Run:
+
+```sh
+just validate
+just shexli
+just toolbox test tests/shell/auroraDock.js
+```
+
+Manual verification should cover:
+
+1. A maximized window with a clickable control behind the hidden dock bounds.
+2. The primary monitor.
+3. Every external monitor, including monitors with negative X/Y coordinates or
+   different vertical alignment.
+4. Repeated edge reveals while a window overlaps the dock.
+5. Moving the pointer from the hot edge into the dock and then away from it.
+6. Rotating one monitor while three or more monitors are active, then revealing
+   and interacting with every dock.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,72 @@
+# Development and Testing
+
+## Setup and Build
+
+- `just deps` installs dependencies with Yarn's immutable mode.
+- `just build` compiles TypeScript and SCSS, copies metadata and schemas, and compiles translations.
+- `just package production` creates the production extension ZIP.
+- `just package development` creates the DevTool-enabled development ZIP.
+- `just package check` builds and inspects both packages.
+- `just install` installs the development package.
+- `just uninstall` disables and removes the extension.
+- `just run` installs the development package and starts a devkit session.
+- `just watch` recompiles SCSS as files change.
+- `just logs` shows recent Aurora entries from the current boot journal.
+
+Use `just clean` to remove `dist/` and `just clean all` to also remove `node_modules/`.
+
+## Validation
+
+- `just validate` runs TypeScript, ESLint, Prettier, and Stylelint checks.
+- `just lint` runs ESLint only.
+- `just test unit` runs Shell-free unit tests with the Node test runner.
+- `just test coverage` runs unit tests with coverage.
+- `just shexli` packages the extension and runs the extensions.gnome.org static analyzer.
+
+Pure logic belongs in `tests/unit/`. GNOME Shell, St, and Clutter integration belongs in
+`tests/shell/`.
+
+## Shell Integration Tests
+
+Run one feature test on the host with:
+
+```bash
+just test shell tests/shell/auroraTrayIcons.js
+```
+
+Run all Shell tests with `just test all`, or use the preferred Toolbox environment:
+
+```bash
+just toolbox create
+just toolbox test all
+```
+
+The Toolbox uses the public, versioned GNOME image from
+`ghcr.io/luminusos/aurora-shell-ci`. Set `AURORA_TOOLBOX_IMAGE` to test a local replacement and
+`AURORA_TOOLBOX_NAME` when maintaining multiple development toolboxes. `Vagrantfile` remains
+available for manual testing against other GNOME environments.
+
+## CI Environment
+
+`Containerfile` defines the Fedora/GNOME environment shared by CI and Toolbox. Its image tag is
+derived from the first `shell-version` in `metadata.json` and a hash of the container inputs. CI
+publishes a missing amd64 and arm64 image before running validation jobs.
+
+To target a new GNOME generation, update `metadata.json`, the GNOME type dependencies, and
+`FEDORA_VERSION` in `Containerfile`. The content change produces a new image tag automatically.
+
+Every pull request runs four checks from `.github/workflows/ci.yml`:
+
+1. Validation with `just validate`.
+2. Unit and regression tests.
+3. Package inspection with `just package check`.
+4. Headless GNOME Shell integration tests.
+
+The isolated integration runtime owns its private `XDG_RUNTIME_DIR`, system D-Bus, and logind mock;
+Toolbox does not replace the host services.
+
+## GNOME Extensions Review
+
+Run `just shexli` to scan the production ZIP. The command uses an installed `shexli`, or falls back
+to `uvx --from shexli shexli` when available. Review every finding and document accepted warnings
+in [GNOME Extensions review notes](extension-review.md).

--- a/docs/extension-review.md
+++ b/docs/extension-review.md
@@ -1,4 +1,4 @@
-# EGO Review Notes
+# GNOME Extensions Review Notes
 
 This file records the Aurora Shell review baseline for
 [the GNOME Extensions review guidelines](https://gjs.guide/extensions/review-guidelines/review-guidelines.html)

--- a/docs/gnome-shell-adapter.md
+++ b/docs/gnome-shell-adapter.md
@@ -1,0 +1,214 @@
+# Vale a pena usar o `GnomeShellAdapter`?
+
+> Documento de decisão arquitetural. Avalia, com fontes, se a abstração
+> `GnomeShellAdapter` / `ShellEnvironment` (a camada de injeção de dependência que
+> embrulha o singleton global `Main`) compensa para esta extensão.
+>
+> Data: 2026-05-31 · Status: **decidido — Opção C aplicada** (adapter removido)
+
+> **Decisão (2026-05-31):** o `GnomeShellAdapter`/`ShellEnvironment` foi **removido**
+> (Opção C). Justificativa do mantenedor: os testes de integração rodam um GNOME Shell
+> real via `gnome-shell-test-tool` — o problema histórico de "não dá para testar com o
+> shell" ficou no passado — e a lógica pura é coberta por unit tests (`node --test`), com
+> tipos vindos de `@girs`. `noOverview` e `privacyPanel` passaram a importar `Main`
+> diretamente; `ExtensionContext` mantém apenas `settings` e `signals`. O restante deste
+> documento é a análise que levou à decisão.
+
+---
+
+## 1. O que é o adapter aqui
+
+`src/core/adapters/shell.ts` define a interface `ShellEnvironment` e a implementação
+`GnomeShellAdapter`, que embrulha um punhado de APIs do objeto global `Main`
+(`resource:///org/gnome/shell/ui/main.js`):
+
+```ts
+export interface ShellEnvironment {
+  readonly isStartingUp: boolean;     // Main.layoutManager._startingUp
+  hasOverview: boolean;               // Main.sessionMode.hasOverview
+  hideOverview(): void;               // Main.overview.hide()
+  onStartupComplete(cb: () => void): number; // Main.layoutManager.connect('startup-complete', …)
+  disconnect(id: number): void;
+}
+```
+
+Os módulos recebem isso via `ExtensionContext` (`this.context.shell`) em vez de
+importar `Main` diretamente. O objetivo declarado no próprio arquivo é:
+
+> *"Abstracting this allows us to test modules without a real GNOME Shell instance."*
+
+A pergunta deste documento é: **esse objetivo está sendo cumprido, e o custo se paga?**
+
+---
+
+## 2. Contexto: por que testar extensões GNOME é difícil
+
+A motivação original do adapter (testabilidade) só faz sentido se entendermos por que
+testar código de extensão é difícil. As limitações são reais e documentadas:
+
+- **O processo do shell não é importável fora dele.** A documentação oficial de
+  depuração afirma: *"The GJS console is a separate process, without access to the
+  `gnome-shell` process or the ability to import JavaScript modules used by
+  extensions."* ([gjs.guide – Debugging][gjs-debug])
+- **Você não consegue importar `Main`/`St`/`Shell` num runner de teste normal (Node,
+  vitest).** Como a comunidade resume: *"it is impossible for gjs to import some things
+  (for example `imports.gi.St`), so you will only be able to test files which don't
+  import any stuff gjs can't import."* ([javascript-list, GNOME mailing list][gjs-ml])
+- **A própria documentação de extensões praticamente não fala de testes unitários** — o
+  fluxo oficial recomendado é abrir um novo processo do shell para carregar mudanças
+  ([gjs.guide – Debugging][gjs-debug]).
+
+Ou seja: qualquer arquivo que faça `import * as Main from '…/ui/main.js'` **não pode ser
+carregado** num teste unitário fora do shell. É exatamente esse problema que um adapter
++ injeção de dependência tenta contornar: se o módulo depende de uma *interface* sua
+(`ShellEnvironment`) e não do `Main` real, o teste pode injetar um dublê e exercitar a
+lógica sem o shell.
+
+Esse é o **argumento teórico a favor**, e ele é legítimo: injeção de dependência é a
+forma canônica de tornar testável código preso a dependências globais. Martin Fowler:
+*"A common reason people give for preferring dependency injection is that it makes
+testing easier… to do testing, you need to easily replace real service implementations
+with stubs or mocks."* ([Fowler – Inversion of Control & DI][fowler-di])
+
+---
+
+## 3. Argumentos A FAVOR do adapter
+
+1. **Testabilidade da lógica de orquestração.** Módulos como `noOverview` têm lógica de
+   máquina de estados ("se está iniciando, esconda o overview; quando o startup
+   completar, restaure") que vale a pena testar sem subir o shell. Com o adapter, dá
+   para injetar um `ShellEnvironment` falso e verificar a sequência de chamadas.
+
+2. **Mockar o que você *é dono*, não o GNOME.** A regra amplamente repetida é *"don't
+   mock what you don't own"*: você só deve criar dublês de tipos do seu próprio código,
+   não de bibliotecas de terceiros, porque APIs alheias mudam sem aviso e os mocks ficam
+   frágeis ([objc.io – Test Doubles][objc-doubles]; [TDD anti-patterns][codurance]). O
+   `ShellEnvironment` é justamente um tipo **seu** que fica na fronteira com o GNOME —
+   um "port" no sentido de arquitetura hexagonal. Testar contra ele respeita essa regra;
+   tentar mockar `Main` diretamente a violaria.
+
+3. **Documenta a superfície de acoplamento.** A interface lista explicitamente *quais*
+   pedaços do shell o código depende. Isso vira um inventário de risco útil quando uma
+   nova versão do GNOME muda APIs internas (ver [Release Policy][agents] — features
+   acompanham o ciclo do GNOME).
+
+4. **Ponto único de adaptação a quebras de versão.** Se `Main.layoutManager._startingUp`
+   sumir num GNOME futuro, conserta-se em um arquivo, não em N módulos.
+
+---
+
+## 4. Argumentos CONTRA (como está hoje)
+
+Aqui entra a evidência específica deste repositório — e ela é desfavorável.
+
+1. **O benefício (testes) NÃO está sendo colhido.** Não existe **nenhum** teste unitário
+   que injete um `ShellEnvironment` falso. Os testes em `tests/unit/`
+   (`metadata`, `monitorTopology`, `registry`, `schema`, `trayState`) ou (a) analisam
+   código-fonte como texto, ou (b) testam lógica pura que já não depende do shell. A
+   cobertura real de comportamento vem dos **testes de integração** em `tests/shell/`,
+   que rodam um `gnome-shell` de verdade headless — e portanto **não precisam do adapter
+   para nada**. Uma abstração cujo único propósito é testabilidade, sem um único teste
+   que a use, é custo sem retorno.
+
+2. **A abstração cobre quase nada.** Apenas **2 de 13 módulos** usam `this.context.shell`
+   (`noOverview` e `privacyPanel`). A interface expõe ~4 chamadas. Enquanto isso, **~12
+   módulos importam `Main` diretamente** (`dock`, `trayIcons`, `volumeMixer`, `privacy`,
+   `clipboardHistory`, `bluetoothMenu`, `appSearchTooltip`, etc.) e usam dezenas de APIs
+   (`Main.panel`, `statusArea`, `addToStatusArea`, `wm`, `uiGroup`, `overview`, …). A
+   "fronteira" está cheia de furos: o adapter dá uma falsa sensação de desacoplamento.
+
+3. **Importar `Main` direto é prática aceita e idiomática.** A documentação oficial e
+   praticamente toda extensão fazem `import * as Main from
+   'resource:///org/gnome/shell/ui/main.js'` ([gjs.guide – Imports & Modules][gjs-imports]).
+   Não é um anti-padrão a ser exterminado; é a API pública de fato para extensões.
+
+4. **Custo de consistência e parmetragem.** Ter uma regra de DI no `AGENTS.md`
+   ("módulos **não devem** acessar `Main` diretamente") que **11 de 13 módulos violam**
+   gera ruído: revisões apontam "violação", contribuidores ficam em dúvida sobre qual
+   padrão seguir, e o adapter precisa crescer toda vez que um módulo "bem-comportado"
+   precisa de uma API nova. Expandir o adapter para cobrir `panel`, `statusArea`, `wm`,
+   etc., seria reescrever muito código para espelhar a API do `Main` — um *wrapper
+   anêmico* que só repassa chamadas, o tipo de indireção que adiciona manutenção sem
+   adicionar valor.
+
+---
+
+## 5. Análise
+
+O adapter é uma boa ideia **mal calibrada para esta base de código**. O padrão (port na
+fronteira + DI) é correto e alinhado às melhores práticas — *quando há testes que o
+exercitam*. Hoje não há, e a superfície coberta é pequena demais para o adapter ser uma
+fronteira real.
+
+Os testes de integração em `gnome-shell` headless já entregam a confiança que o adapter
+prometia entregar via unit tests, **e cobrem os 13 módulos**, não 2. Para extensões, esse
+é frequentemente o trade-off certo: o ambiente é tão entrelaçado com o shell que testar
+contra um shell real (como o próprio GNOME faz, com serviços mockados via
+python-dbusmock — [Automated testing of GNOME Shell][gnome-auto]) rende mais que erguer e
+manter uma camada de abstração para unit tests que ninguém escreve.
+
+> Princípio aplicável: a abstração deve pagar seu custo. *"With your codebase, you
+> probably have a sense of how stable or volatile different interfaces are, so you can
+> use your gut feeling about when using a double might lead to brittle tests."*
+> ([objc.io][objc-doubles]) Uma abstração sem consumidor de teste é volatilidade pura.
+
+---
+
+## 6. Recomendação
+
+Três caminhos coerentes (escolher um — **não** ficar no meio-termo atual):
+
+### Opção A — Cumprir a promessa (manter e *usar* o adapter)
+Faz sentido **se** houver intenção real de escrever unit tests de lógica de módulos.
+- Escrever de fato testes que injetem um `FakeShellEnvironment` (ex.: testar a máquina de
+  estados do `noOverview`/`privacyPanel`).
+- Expandir o adapter **apenas** onde houver lógica que valha testar isolada — não tentar
+  espelhar todo o `Main`.
+- Manter a regra de DI no `AGENTS.md`, mas reescrita para refletir que ela vale para
+  *lógica testável*, não para todo toque em `Main`.
+
+### Opção B — Encolher para uma fronteira honesta (recomendada)
+Manter o adapter **só** para o que tem lógica não-trivial de ciclo de vida
+(`isStartingUp` + `onStartupComplete`, usados por `noOverview`/`privacyPanel`), e
+**parar de fingir** que os outros módulos não usam `Main`.
+- Reescrever a regra do `AGENTS.md`: importar `Main` diretamente é permitido e idiomático;
+  o `ShellEnvironment` existe apenas para encapsular o handshake de *startup* (que é
+  chato de testar e propenso a quebrar entre versões).
+- Resultado: zero reescrita grande, a regra para de ser violada por 11 módulos, e a
+  abstração passa a ter um escopo defensável.
+
+### Opção C — Remover o adapter
+Se não houver plano de unit tests de comportamento, remover `ShellEnvironment` e fazer
+`noOverview`/`privacyPanel` importarem `Main` como os demais.
+- Menos uma camada, menos uma regra violada, confiança vem 100% dos testes de integração.
+- Custo: perde-se o ponto único de adaptação ao *startup handshake* entre versões do
+  GNOME — o único lugar onde o adapter agrega valor concreto hoje.
+
+**Sugestão:** **Opção B**. Ela alinha a regra à realidade (importar `Main` é normal),
+elimina o atrito de revisão, e preserva a abstração exatamente no único ponto em que ela
+paga seu custo: o ciclo de *startup*, que é genuinamente irritante de testar e sensível a
+versão. As Opções A e C são defensáveis conforme a equipe decida investir (A) ou não (C)
+em unit tests de lógica de módulo.
+
+---
+
+## Fontes
+
+- [gjs.guide — Debugging extensions (limitações do console GJS / testes)][gjs-debug]
+- [gjs.guide — Imports and Modules (import de `Main` via `resource://`)][gjs-imports]
+- [gjs.guide — Review Guidelines (regras de `enable`/`disable`, recursos)][gjs-review]
+- [GNOME mailing list — Unit testing under GJS (não dá para importar `imports.gi.St`)][gjs-ml]
+- [GNOME Shell & Mutter — Automated testing of GNOME Shell (mocks via python-dbusmock)][gnome-auto]
+- [Martin Fowler — Inversion of Control Containers and the Dependency Injection pattern][fowler-di]
+- [objc.io — Test Doubles: Mocks, Stubs, and More ("don't mock what you don't own")][objc-doubles]
+- [Codurance — TDD anti-patterns (fragilidade de mockar dependências externas)][codurance]
+
+[gjs-debug]: https://gjs.guide/extensions/development/debugging.html
+[gjs-imports]: https://gjs.guide/extensions/overview/imports-and-modules.html
+[gjs-review]: https://gjs.guide/extensions/review-guidelines/review-guidelines.html
+[gjs-ml]: https://mail.gnome.org/archives/javascript-list/2017-December/msg00000.html
+[gnome-auto]: https://blogs.gnome.org/shell-dev/2022/12/02/automated-testing-of-gnome-shell/
+[fowler-di]: https://martinfowler.com/articles/injection.html
+[objc-doubles]: https://www.objc.io/issues/15-testing/mocking-stubbing/
+[codurance]: https://www.codurance.com/publications/tdd-anti-patterns-chapter-2
+[agents]: ../AGENTS.md

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,68 @@
+# Adding and Maintaining Modules
+
+## Add a Module
+
+1. Add `feature.manifest.ts` and its runtime implementation in the appropriate functional area.
+2. Import the manifest into `moduleCatalog.ts` in preference order.
+3. Associate the manifest key with its factory in `registry.ts`.
+4. Add every module, option, and internal key to the GSettings schema.
+5. Add unit coverage for pure logic and a Shell integration test for GNOME behavior.
+
+A minimal manifest looks like this:
+
+```typescript
+import { gettext as _ } from 'gettext';
+import type { ModuleManifest } from '~/module.ts';
+
+export const manifest: ModuleManifest = {
+  key: 'my-module',
+  settingsKey: 'module-my-module',
+  section: 'behavior',
+  title: _('My Module'),
+  subtitle: _('Description'),
+  runtime: { roles: ['desktop'], scope: 'session' },
+  options: [
+    {
+      key: 'my-option',
+      title: _('Option'),
+      subtitle: _('Description'),
+      type: 'switch',
+    },
+  ],
+};
+```
+
+`tests/unit/registry.test.ts` enforces catalog order, uniqueness, known sections, and factory
+coverage. `tests/unit/schema.test.ts` requires manifest-declared setting keys to match the schema.
+
+## Lifecycle and Dependencies
+
+Implement the small `enable()` and `disable()` contract. Create a fresh `LifecycleScope` for each
+enable cycle so signal connections and teardown callbacks are released in reverse order. Keep
+timers, D-Bus subscriptions, and other stateful GNOME APIs explicit at their call sites.
+
+Read settings through the shared context. Direct imports of `Main`, Shell, St, and Clutter are
+idiomatic for GNOME integration; extract complex calculations into Shell-free TypeScript when they
+can be tested independently. See the [adapter decision](gnome-shell-adapter.md) for the rationale.
+
+## Coding Conventions
+
+- Name TypeScript files with `camelCase` and classes with `PascalCase`.
+- Prefix private members with `_` and use `UPPER_CASE` for constants.
+- Disconnect or destroy everything connected or created during `enable()`.
+- Keep manifests free of Shell UI imports so preferences can load the catalog safely.
+
+## Logging
+
+Use `logger` from `~/core/logger.ts` instead of `console` or direct GLib logging. Prefix messages
+with the module name in `PascalCase` brackets:
+
+```typescript
+import { logger } from '~/core/logger.ts';
+
+logger.log('[AuroraTray] Item added: ' + id);
+logger.warn('[IconWeave] No match found for ' + wmClass);
+```
+
+Do not add an `[Aurora Shell]` prefix; the structured log identifier already routes entries to the
+extension.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,42 @@
+# Releases and Backports
+
+Aurora Shell follows the GNOME Shell release cycle. `main` targets the next GNOME release, while
+branches such as `release/v50.x` and `release/v51.x` receive maintenance fixes for released GNOME
+versions.
+
+## Features and Fixes
+
+Land new features on `main`. Maintenance branches accept only bug fixes and compatibility updates.
+
+Bug fixes also target `main` first. When a maintenance release needs the fix, create a separate
+backport pull request based on the release branch:
+
+```bash
+git checkout release/v50.x
+git cherry-pick <commit-sha>
+```
+
+Maintainers decide which fixes warrant backports. A label such as `GNOME 50` on the original pull
+request requests an automated backport after merge. The automation rebuilds its branch from the
+target release, cherry-picks the original commits, and adds the next patch-version bump.
+
+## Release Candidates
+
+Release candidate tags use `v50-rc1`, `v50-rc2`, and so on. Trigger the `Release` workflow manually;
+it chooses the next candidate number, tags current `main`, runs CI, and publishes a pre-release.
+Publishing a release candidate removes nightly pre-releases that it supersedes.
+
+Nightly and release candidate publications include both the production ZIP and the separate
+DevTool-enabled development ZIP.
+
+## Stable Releases
+
+Stable tags use the GNOME major version and an Aurora patch number, such as `v50.1`:
+
+```bash
+git tag -a v50.1 -m "Release v50.1"
+git push origin v50.1
+```
+
+The release workflow calls the complete CI pipeline and publishes both extension packages after
+all checks pass. The first tag for a GNOME major version also establishes its maintenance branch.


### PR DESCRIPTION
Keep repository entry points at the root and move specialized guidance into a structured docs index. Split development, module, release, architecture, and review guidance into focused documents and define the project commit-message convention.