### PR TITLE
fix(ci): grant reusable workflow permissions

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: read
 
 concurrency:
   group: nightly-pre-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: read
 
 jobs:
   state:


### PR DESCRIPTION
Grant pull request read access to the release and nightly workflows so the reusable CI workflow cannot request permissions unavailable to its callers.

This fixes the startup failure that prevented workflow-dispatch runs from creating any jobs.

Validation:
- actionlint
- git diff --check