### PR TITLE
feat(dock): add configurable icon sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Aurora is split into independent modules, so you can enable only what you want.
 
 ### Dock & Panel
 
-- **Dock** - replaces the stock dash with a per-monitor dock that always auto-hides by default, with optional intellihide and always-visible modes, edge reveal, Trash, and removable drive shortcuts.
+- **Dock** - replaces the stock dash with a per-monitor dock that always auto-hides by default, with optional intellihide and always-visible modes, adjustable icon size, edge reveal, Trash, and removable drive shortcuts.
 - **Aurora Menu** - adds an Aurora panel menu with recent items, useful shortcuts, configurable panel icon, optional Activities button hiding, and a custom command slot.
 - **Volume Mixer** - adds per-application volume sliders to Quick Settings with fast access to Sound Settings.
 - **Low Battery Percentage** - uses GNOME's native battery percentage setting while the battery is discharging below 20%, without overriding users who already enabled it.

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aurora-shell\n"
 "Report-Msgid-Bugs-To: https://github.com/luminusOS/aurora-shell/issues\n"
-"POT-Creation-Date: 2026-07-31 15:36-0300\n"
+"POT-Creation-Date: 2026-08-15 17:00-0300\n"
 "PO-Revision-Date: 2026-07-16 09:20-0300\n"
 "Last-Translator: Aurora Shell Contributors\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -16,118 +16,110 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: dist/capture/captureTools.js:40
-msgid "Selection"
-msgstr "Seleção"
-
-#: dist/capture/captureTools.js:41
-msgid "Pointer"
-msgstr "Ponteiro"
-
-#: dist/capture/captureTools.js:42
-msgid "Freehand"
-msgstr "Desenho livre"
-
-#: dist/capture/captureTools.js:43
-msgid "Rectangle"
-msgstr "Retângulo"
-
-#: dist/capture/captureTools.js:44
-msgid "Solid rectangle"
-msgstr "Retângulo preenchido"
-
-#: dist/capture/captureTools.js:45
-msgid "Highlighter"
-msgstr "Marca-texto"
-
-#: dist/capture/captureTools.js:46
-msgid "Arrow"
-msgstr "Seta"
-
-#: dist/capture/captureTools.js:47
-msgid "Text"
-msgstr "Texto"
-
-#: dist/capture/captureTools.js:48
-msgid "Numbered marker"
-msgstr "Marcador numerado"
-
-#: dist/capture/captureTools.js:113 dist/capture/captureTools.js:366
+#: dist/capture/captureOcrSession.js:27 dist/capture/captureOcrSession.js:213
 msgid "Extract text"
 msgstr "Extrair texto"
 
-#: dist/capture/captureTools.js:268 dist/capture/captureTools.js:289
-msgid "Screenshot failed"
-msgstr "Falha na captura de tela"
-
-#: dist/capture/captureTools.js:268 dist/capture/captureTools.js:289
-msgid "Could not export the annotated screenshot"
-msgstr "Não foi possível exportar a captura de tela anotada"
-
-#: dist/capture/captureTools.js:301
-msgid "Move toolbar"
-msgstr "Mover barra de ferramentas"
-
-#: dist/capture/captureTools.js:325
-msgid "Annotation color"
-msgstr "Cor da anotação"
-
-#: dist/capture/captureTools.js:341
-msgid "Annotation width"
-msgstr "Espessura da anotação"
-
-#: dist/capture/captureTools.js:353
-msgid "Undo"
-msgstr "Desfazer"
-
-#: dist/capture/captureTools.js:356
-msgid "Clear annotations"
-msgstr "Limpar anotações"
-
-#: dist/capture/captureTools.js:380 dist/capture/captureTools.js:384
-msgid "Copy text"
-msgstr "Copiar texto"
-
-#: dist/capture/captureTools.js:385 dist/capture/captureTools.js:389
-msgid "Search the web"
-msgstr "Pesquisar na web"
-
-#: dist/capture/captureTools.js:501
-msgid "Type annotation text"
-msgstr "Digite o texto da anotação"
-
-#: dist/capture/captureTools.js:543 dist/capture/captureTools.js:574
-#: dist/capture/captureTools.js:597
+#: dist/capture/captureOcrSession.js:83 dist/capture/captureOcrSession.js:168
+#: dist/capture/captureOcrSession.js:289
 msgid "OCR"
 msgstr "OCR"
 
-#: dist/capture/captureTools.js:543
+#: dist/capture/captureOcrSession.js:83
 msgid "No text found in the screenshot"
 msgstr "Nenhum texto encontrado na captura de tela"
 
-#: dist/capture/captureTools.js:557
+#: dist/capture/captureOcrSession.js:98
 msgid "OCR unavailable"
 msgstr "OCR indisponível"
 
-#: dist/capture/captureTools.js:557
+#: dist/capture/captureOcrSession.js:98
 msgid "Tesseract OCR and language data are not installed"
 msgstr "O Tesseract OCR e os dados de idioma não estão instalados"
 
-#: dist/capture/captureTools.js:560
+#: dist/capture/captureOcrSession.js:101
 msgid "OCR failed"
 msgstr "Falha no OCR"
 
-#: dist/capture/captureTools.js:560
+#: dist/capture/captureOcrSession.js:101
 msgid "Text recognition failed"
 msgstr "Falha no reconhecimento de texto"
 
-#: dist/capture/captureTools.js:574
+#: dist/capture/captureOcrSession.js:168
 msgid "Recognized text copied"
 msgstr "Texto reconhecido copiado"
 
-#: dist/capture/captureTools.js:597
+#: dist/capture/captureOcrSession.js:227 dist/capture/captureOcrSession.js:231
+msgid "Copy text"
+msgstr "Copiar texto"
+
+#: dist/capture/captureOcrSession.js:232 dist/capture/captureOcrSession.js:236
+msgid "Search the web"
+msgstr "Pesquisar na web"
+
+#: dist/capture/captureOcrSession.js:289
 msgid "Could not open the web search"
 msgstr "Não foi possível abrir a pesquisa na web."
+
+#: dist/capture/captureToolbar.js:22
+msgid "Selection"
+msgstr "Seleção"
+
+#: dist/capture/captureToolbar.js:23
+msgid "Pointer"
+msgstr "Ponteiro"
+
+#: dist/capture/captureToolbar.js:24
+msgid "Freehand"
+msgstr "Desenho livre"
+
+#: dist/capture/captureToolbar.js:25
+msgid "Rectangle"
+msgstr "Retângulo"
+
+#: dist/capture/captureToolbar.js:26
+msgid "Solid rectangle"
+msgstr "Retângulo preenchido"
+
+#: dist/capture/captureToolbar.js:27
+msgid "Highlighter"
+msgstr "Marca-texto"
+
+#: dist/capture/captureToolbar.js:28
+msgid "Arrow"
+msgstr "Seta"
+
+#: dist/capture/captureToolbar.js:29
+msgid "Text"
+msgstr "Texto"
+
+#: dist/capture/captureToolbar.js:30
+msgid "Numbered marker"
+msgstr "Marcador numerado"
+
+#: dist/capture/captureToolbar.js:43
+msgid "Move toolbar"
+msgstr "Mover barra de ferramentas"
+
+#: dist/capture/captureToolbar.js:63
+msgid "Annotation color"
+msgstr "Cor da anotação"
+
+#: dist/capture/captureToolbar.js:81
+msgid "Annotation width"
+msgstr "Espessura da anotação"
+
+#: dist/capture/captureToolbar.js:90
+msgid "Undo"
+msgstr "Desfazer"
+
+#: dist/capture/captureToolbar.js:93
+msgid "Clear annotations"
+msgstr "Limpar anotações"
+
+#: dist/capture/captureTools.js:225
+msgid "Type annotation text"
+msgstr "Digite o texto da anotação"
 
 #: dist/capture/captureTools.manifest.js:8
 msgid "Capture Tools"
@@ -181,14 +173,27 @@ msgstr "Bing"
 msgid "Screenshot taken"
 msgstr "Captura de tela realizada"
 
-#: dist/capture/screenshotCapture.js:205
+#: dist/capture/screenshotCapture.js:206
 msgid "Screenshots"
 msgstr "Capturas de tela"
 
-#: dist/capture/screenshotCapture.js:213
+#: dist/capture/screenshotCapture.js:214
 #, javascript-format
 msgid "Screenshot From %s"
 msgstr "Captura de tela de %s"
+
+#: dist/capture/screenshotHooks.js:86
+msgid "Screenshot failed"
+msgstr "Falha na captura de tela"
+
+#: dist/capture/screenshotHooks.js:86
+msgid "Could not export the annotated screenshot"
+msgstr "Não foi possível exportar a captura de tela anotada"
+
+#: dist/clipboard/clipboardCardBuilders.js:125
+#, javascript-format
+msgid "%d lines"
+msgstr "%d linhas"
 
 #: dist/clipboard/clipboardHistory.manifest.js:8
 msgid "Clipboard History"
@@ -229,24 +234,19 @@ msgstr "Intervalo de verificação (ms)"
 msgid "How often to check the clipboard for changes"
 msgstr "Frequência de verificação de alterações na área de transferência"
 
-#: dist/clipboard/clipboardItem.js:324
-#, javascript-format
-msgid "%d lines"
-msgstr "%d linhas"
-
-#: dist/clipboard/clipboardItem.js:383
+#: dist/clipboard/clipboardItem.js:148
 msgid "Copy"
 msgstr "Copiar"
 
-#: dist/clipboard/clipboardItem.js:386
+#: dist/clipboard/clipboardItem.js:151
 msgid "Unpin"
 msgstr "Desafixar"
 
-#: dist/clipboard/clipboardItem.js:386
+#: dist/clipboard/clipboardItem.js:151
 msgid "Pin"
 msgstr "Fixar"
 
-#: dist/clipboard/clipboardItem.js:389
+#: dist/clipboard/clipboardItem.js:154
 msgid "Delete"
 msgstr "Excluir"
 
@@ -262,12 +262,12 @@ msgstr "Copie textos, links, códigos ou imagens para vê-los aqui."
 msgid "Search…"
 msgstr "Pesquisar…"
 
-#: dist/desktop/trayIcons/backgroundAppsSource.js:109
-#: dist/dock/externalStorageIcon.js:249 dist/dock/trashIcon.js:107
+#: dist/desktop/trayIcons/backgroundAppsSource.js:112
+#: dist/dock/externalStorageIcon.js:97 dist/dock/trashIcon.js:108
 msgid "Open"
 msgstr "Abrir"
 
-#: dist/desktop/trayIcons/backgroundAppsSource.js:111
+#: dist/desktop/trayIcons/backgroundAppsSource.js:114
 msgid "Quit"
 msgstr "Sair"
 
@@ -373,69 +373,80 @@ msgstr ""
 "mostra todos os aplicativos do espaço de trabalho"
 
 #: dist/dock/dock.manifest.js:33
+msgid "Maximum Icon Size"
+msgstr "Tamanho máximo dos ícones"
+
+#: dist/dock/dock.manifest.js:35
+msgid ""
+"Maximum dock icon size in pixels (16–64); shrinks automatically when needed"
+msgstr ""
+"Tamanho máximo dos ícones da dock em pixels (16–64); reduz automaticamente "
+"quando necessário"
+
+#: dist/dock/dock.manifest.js:44
 msgid "Show Trash Icon"
 msgstr "Mostrar ícone da lixeira"
 
-#: dist/dock/dock.manifest.js:34
+#: dist/dock/dock.manifest.js:45
 msgid "Show a trash can in the dock; click to open it, right-click to empty it"
 msgstr ""
 "Mostra uma lixeira no dock; clique para abri-la e clique com o botão direito "
 "para esvaziá-la"
 
-#: dist/dock/dock.manifest.js:39
+#: dist/dock/dock.manifest.js:50
 msgid "Show External Storage"
 msgstr "Mostrar armazenamento externo"
 
-#: dist/dock/dock.manifest.js:40
+#: dist/dock/dock.manifest.js:51
 msgid "Show removable drives in the dock when they are connected"
 msgstr "Mostra unidades removíveis no dock quando estão conectadas"
 
-#: dist/dock/dock.manifest.js:45
+#: dist/dock/dock.manifest.js:56
 msgid "Icon Hover &amp; Press Effects"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:46
+#: dist/dock/dock.manifest.js:57
 msgid "Animate dock icons on hover and click"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:51
+#: dist/dock/dock.manifest.js:62
 msgid "Effect Intensity"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:52
+#: dist/dock/dock.manifest.js:63
 msgid "How strong the hover and press effects are"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:55
+#: dist/dock/dock.manifest.js:66
 msgid "Subtle"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:56
+#: dist/dock/dock.manifest.js:67
 msgid "Balanced"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:57
+#: dist/dock/dock.manifest.js:68
 msgid "Expressive"
 msgstr ""
 
-#: dist/dock/externalStorageIcon.js:249
+#: dist/dock/externalStorageIcon.js:97
 msgid "Mount and Open"
 msgstr "Montar e abrir"
 
-#: dist/dock/externalStorageIcon.js:253
+#: dist/dock/externalStorageIcon.js:101
 msgid "Eject"
 msgstr "Ejetar"
 
-#: dist/dock/externalStorageIcon.js:253
+#: dist/dock/externalStorageIcon.js:101
 msgid "Unmount"
 msgstr "Desmontar"
 
-#: dist/dock/externalStorageIcon.js:280
+#: dist/dock/externalStorageOperations.js:53
 #, javascript-format
 msgid "Failed to open “%s”"
 msgstr "Falha ao abrir “%s”"
 
-#: dist/dock/externalStorageIcon.js:332
+#: dist/dock/externalStorageOperations.js:86
 #, javascript-format
 msgid "Failed to eject “%s”"
 msgstr "Falha ao ejetar “%s”"
@@ -444,68 +455,68 @@ msgstr "Falha ao ejetar “%s”"
 msgid "Trash"
 msgstr "Lixeira"
 
-#: dist/dock/trashIcon.js:110
+#: dist/dock/trashIcon.js:111
 msgid "Empty Trash"
 msgstr "Esvaziar lixeira"
 
-#: dist/moduleCatalog.js:27
+#: dist/moduleCatalog.js:28
 msgid "Dock &amp; Panel"
 msgstr "Dock e painel"
 
-#: dist/moduleCatalog.js:28
+#: dist/moduleCatalog.js:29
 msgid "Appearance"
 msgstr "Aparência"
 
-#: dist/moduleCatalog.js:29
+#: dist/moduleCatalog.js:30
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: dist/moduleCatalog.js:30
+#: dist/moduleCatalog.js:31
 msgid "Privacy &amp; Clipboard"
 msgstr "Privacidade e área de transferência"
 
-#: dist/panel/auroraMenu.js:121
+#: dist/panel/auroraMenu.js:154
 msgid "About This PC"
 msgstr "Sobre este computador"
 
-#: dist/panel/auroraMenu.js:128
+#: dist/panel/auroraMenu.js:164
 msgid "Home Folder"
 msgstr "Pasta pessoal"
 
-#: dist/panel/auroraMenu.js:134
+#: dist/panel/auroraMenu.js:170
 msgid "Downloads"
 msgstr "Downloads"
 
-#: dist/panel/auroraMenu.js:144
+#: dist/panel/auroraMenu.js:187
 msgid "System Settings"
 msgstr "Configurações do sistema"
 
-#: dist/panel/auroraMenu.js:150
+#: dist/panel/auroraMenu.js:193
 msgid "Software"
 msgstr "Aplicativos"
 
-#: dist/panel/auroraMenu.js:156
+#: dist/panel/auroraMenu.js:200
 msgid "Extensions"
 msgstr "Extensões"
 
-#: dist/panel/auroraMenu.js:213
+#: dist/panel/auroraMenu.js:265
 msgid "Recent Items"
 msgstr "Itens recentes"
 
-#: dist/panel/auroraMenu.js:219
+#: dist/panel/auroraMenu.js:270
 msgid "No recent items"
 msgstr "Nenhum item recente"
 
-#: dist/panel/auroraMenu.js:341 dist/panel/auroraMenu.js:354
-#: dist/panel/auroraMenu.js:376 dist/panel/auroraMenu.manifest.js:8
+#: dist/panel/auroraMenu.js:342 dist/panel/auroraMenu.js:355
+#: dist/panel/auroraMenu.js:377 dist/panel/auroraMenu.manifest.js:8
 msgid "Aurora Menu"
 msgstr "Menu Aurora"
 
-#: dist/panel/auroraMenu.js:341 dist/panel/auroraMenu.js:354
+#: dist/panel/auroraMenu.js:342 dist/panel/auroraMenu.js:355
 msgid "Could not launch the selected command."
 msgstr "Não foi possível iniciar o comando selecionado."
 
-#: dist/panel/auroraMenu.js:376
+#: dist/panel/auroraMenu.js:377
 msgid "Could not open the selected recent item."
 msgstr "Não foi possível abrir o item recente selecionado."
 
@@ -624,27 +635,27 @@ msgstr ""
 "Mostra o nível da bateria e ícones animados no painel de Configurações "
 "Rápidas do Bluetooth"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:324
+#: dist/panel/clock/meetingClock/meetingAlertController.js:115
 msgid "Meeting starting soon"
 msgstr "Reunião começará em breve"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:332
+#: dist/panel/clock/meetingClock/meetingAlertController.js:124
 msgid "Join"
 msgstr "Participar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:333
+#: dist/panel/clock/meetingClock/meetingAlertController.js:126
 msgid "Snooze"
 msgstr "Adiar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:334
+#: dist/panel/clock/meetingClock/meetingAlertController.js:127
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:335
+#: dist/panel/clock/meetingClock/meetingAlertController.js:129
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: dist/panel/clock/meetingClock/meetingClock.js:477
+#: dist/panel/clock/meetingClock/meetingAlertController.js:186
 #: dist/panel/clock/meetingClock/meetingClock.manifest.js:8
 msgid "Meeting Clock"
 msgstr "Relógio de reuniões"
@@ -757,11 +768,11 @@ msgstr "Avatar no menu de energia"
 msgid "Shows the current user's avatar and name in the power menu"
 msgstr "Mostra o avatar e o nome do usuário atual no menu de energia"
 
-#: dist/panel/volumeMixer/mixerItem.js:114
+#: dist/panel/volumeMixer/mixerItem.js:54
 msgid "Audio"
 msgstr "Áudio"
 
-#: dist/panel/volumeMixer/mixerItem.js:140
+#: dist/panel/volumeMixer/mixerItem.js:76
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -778,12 +789,12 @@ msgid "Sound Settings"
 msgstr "Configurações de som"
 
 #: dist/panel/volumeMixer/volumeMixer.js:95
-#: dist/panel/volumeMixer/volumeMixer.js:114
+#: dist/panel/volumeMixer/volumeMixer.js:117
 #: dist/panel/volumeMixer/volumeMixer.manifest.js:8
 msgid "Volume Mixer"
 msgstr "Mixer de Volume"
 
-#: dist/panel/volumeMixer/volumeMixer.js:124
+#: dist/panel/volumeMixer/volumeMixer.js:127
 msgid "Sound Output"
 msgstr "Saída de som"
 
@@ -899,7 +910,7 @@ msgid "Menu Commands"
 msgstr "Comandos do menu"
 
 #: dist/preferences/commandListEditor.js:63
-#: dist/preferences/commandListEditor.js:230
+#: dist/preferences/commandListEditor.js:232
 msgid "Add Command"
 msgstr "Adicionar comando"
 
@@ -920,7 +931,7 @@ msgid "Move Down"
 msgstr "Mover para baixo"
 
 #: dist/preferences/commandListEditor.js:149
-#: dist/preferences/commandListEditor.js:230
+#: dist/preferences/commandListEditor.js:232
 msgid "Edit Command"
 msgstr "Editar comando"
 
@@ -928,44 +939,44 @@ msgstr "Editar comando"
 msgid "Remove Command"
 msgstr "Remover comando"
 
-#: dist/preferences/commandListEditor.js:169
+#: dist/preferences/commandListEditor.js:171
 msgid "Name"
 msgstr "Nome"
 
-#: dist/preferences/commandListEditor.js:174
+#: dist/preferences/commandListEditor.js:176
 msgid "Command"
 msgstr "Comando"
 
-#: dist/preferences/commandListEditor.js:191
+#: dist/preferences/commandListEditor.js:193
 msgid "The name cannot contain “|”"
 msgstr "O nome não pode conter “|”"
 
-#: dist/preferences/commandListEditor.js:206
+#: dist/preferences/commandListEditor.js:208
 msgid "Choose the name shown in Aurora Menu and the command to run."
 msgstr "Escolha o nome exibido no Menu Aurora e o comando a ser executado."
 
-#: dist/preferences/commandListEditor.js:217
+#: dist/preferences/commandListEditor.js:219
 msgid "Save"
 msgstr "Salvar"
 
-#: dist/preferences/commandListEditor.js:217
+#: dist/preferences/commandListEditor.js:219
 msgid "Add"
 msgstr "Adicionar"
 
-#: dist/preferences/commandListEditor.js:266
+#: dist/preferences/commandListEditor.js:268
 msgid "Remove Command?"
 msgstr "Remover comando?"
 
-#: dist/preferences/commandListEditor.js:267
+#: dist/preferences/commandListEditor.js:269
 #, javascript-format
 msgid "“%s” will be removed from Aurora Menu."
 msgstr "“%s” será removido do Menu Aurora."
 
-#: dist/preferences/commandListEditor.js:272
+#: dist/preferences/commandListEditor.js:274
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: dist/preferences/commandListEditor.js:273
+#: dist/preferences/commandListEditor.js:275
 msgid "Remove"
 msgstr "Remover"
 
@@ -985,11 +996,15 @@ msgstr "Logo do Aurora Shell"
 msgid "Access website"
 msgstr "Acessar website"
 
-#: dist/prefs.js:307 dist/prefs.js:341 dist/prefs.js:348 dist/prefs.js:358
+#: dist/prefs.js:146
+msgid "Reset to Default"
+msgstr "Restaurar padrão"
+
+#: dist/prefs.js:324 dist/prefs.js:359 dist/prefs.js:366 dist/prefs.js:376
 msgid "Disabled"
 msgstr "Desativado"
 
-#: dist/prefs.js:336
+#: dist/prefs.js:354
 msgid "Press a shortcut…"
 msgstr "Pressione um atalho…"
 

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -132,6 +132,12 @@
       <summary>Show dock on all monitors</summary>
       <description>Show the dock on every eligible monitor instead of only on the primary monitor</description>
     </key>
+    <key name="dock-icon-size" type="i">
+      <range min="16" max="64"/>
+      <default>64</default>
+      <summary>Maximum dock icon size</summary>
+      <description>Maximum dock icon size in logical pixels; icons shrink automatically when space is limited</description>
+    </key>
     <key name="dock-show-trash" type="b">
       <default>true</default>
       <summary>Show trash icon</summary>

--- a/src/dev/devTool.ts
+++ b/src/dev/devTool.ts
@@ -71,7 +71,7 @@ export class DevTool extends Module {
     this._tools = {
       general: new GeneralDevTool(this._callbacks.openPreferences),
       captureTools: new CaptureToolsDevTool(this._callbacks.getModule, rebuildMenu),
-      dock: new DockDevTool(this._callbacks.getModule, rebuildMenu),
+      dock: new DockDevTool(this.context.settings, this._callbacks.getModule, rebuildMenu),
       clipboardHistory: new ClipboardHistoryDevTool(this._callbacks.getModule, rebuildMenu),
       trayIcons: new TrayIconsDevTool(rebuildMenu),
       weatherClock: new WeatherClockDevTool(this._callbacks.getModule, rebuildMenu),

--- a/src/dev/dockDevTool.ts
+++ b/src/dev/dockDevTool.ts
@@ -3,6 +3,7 @@ import '@girs/gjs';
 import St from '@girs/st-18';
 import Clutter from '@girs/clutter-18';
 
+import type { SettingsManager } from '~/core/settings.ts';
 import type { Module } from '~/module.ts';
 import { Dock, type ManagedDockBinding } from '~/dock/dock.ts';
 import { OverlapStatus } from '~/dock/intellihide.ts';
@@ -13,12 +14,16 @@ import {
   createDevToolSummary,
 } from '~/dev/devToolUi.ts';
 
+const MIN_ICON_SIZE = 16;
+const MAX_ICON_SIZE = 64;
+
 export class DockDevTool {
   readonly key = 'dock';
   readonly title = 'Dock';
   readonly iconName = 'view-app-grid-symbolic';
 
   constructor(
+    private readonly _settings: SettingsManager,
     private readonly _getModule: (key: string) => Module | null,
     private readonly _requestMenuRebuild: () => void,
   ) {}
@@ -26,14 +31,16 @@ export class DockDevTool {
   buildPanel(): St.Widget {
     const dock = this._getDock();
     const panel = createDevToolModulePanel();
-    panel.add_child(
-      createDevToolSummary(
-        this.iconName,
-        dock
-          ? `Bindings: ${dock.bindings.length} · Always-show: ${dock.alwaysShow ? 'on' : 'off'} · Intellihide: ${dock.intellihideEnabled ? 'on' : 'off'}`
-          : 'Dock disabled',
-      ),
-    );
+    const iconSize = this._settings.getInt('dock-icon-size');
+    const summary = dock
+      ? [
+          `Bindings: ${dock.bindings.length}`,
+          `Icon size: ${iconSize}px`,
+          `Always-show: ${dock.alwaysShow ? 'on' : 'off'}`,
+          `Intellihide: ${dock.intellihideEnabled ? 'on' : 'off'}`,
+        ].join(' · ')
+      : 'Dock disabled';
+    panel.add_child(createDevToolSummary(this.iconName, summary));
 
     if (dock) {
       for (const binding of dock.bindings) panel.add_child(this._buildMonitorPanel(binding));
@@ -67,6 +74,25 @@ export class DockDevTool {
     );
     panel.add_child(secondRow);
 
+    const iconSizeRow = createDevToolActionRow();
+    iconSizeRow.add_child(
+      createDevToolActionButton(
+        'zoom-out-symbolic',
+        'Smaller Icons',
+        () => this.decreaseIconSize(),
+        !dock || iconSize <= MIN_ICON_SIZE,
+      ),
+    );
+    iconSizeRow.add_child(
+      createDevToolActionButton(
+        'zoom-in-symbolic',
+        'Larger Icons',
+        () => this.increaseIconSize(),
+        !dock || iconSize >= MAX_ICON_SIZE,
+      ),
+    );
+    panel.add_child(iconSizeRow);
+
     return panel;
   }
 
@@ -98,6 +124,24 @@ export class DockDevTool {
     const dock = this._getDock();
     if (!dock) return false;
     dock.toggleAlwaysShow();
+    this._requestMenuRebuild();
+    return true;
+  }
+
+  decreaseIconSize(): boolean {
+    if (!this._getDock()) return false;
+
+    const currentSize = this._settings.getInt('dock-icon-size');
+    this._settings.setInt('dock-icon-size', Math.max(MIN_ICON_SIZE, currentSize - 1));
+    this._requestMenuRebuild();
+    return true;
+  }
+
+  increaseIconSize(): boolean {
+    if (!this._getDock()) return false;
+
+    const currentSize = this._settings.getInt('dock-icon-size');
+    this._settings.setInt('dock-icon-size', Math.min(MAX_ICON_SIZE, currentSize + 1));
     this._requestMenuRebuild();
     return true;
   }

--- a/src/dock/dock.manifest.ts
+++ b/src/dock/dock.manifest.ts
@@ -29,6 +29,15 @@ export const manifest: ModuleManifest = {
       type: 'switch',
     },
     {
+      key: 'dock-icon-size',
+      title: _('Maximum Icon Size'),
+      subtitle: _('Maximum dock icon size in pixels (16–64); shrinks automatically when needed'),
+      type: 'spin',
+      min: 16,
+      max: 64,
+      resettable: true,
+    },
+    {
       key: 'dock-show-trash',
       title: _('Show Trash Icon'),
       subtitle: _('Show a trash can in the dock; click to open it, right-click to empty it'),

--- a/src/dock/dock.ts
+++ b/src/dock/dock.ts
@@ -35,6 +35,7 @@ export class Dock extends Module {
   private _alwaysShow = false;
   private _intellihideEnabled = false;
   private _showOnAllMonitors = false;
+  private _maxIconSize = 64;
   private _showTrash = true;
   private _showExternalStorage = true;
   private _motionEnabled = true;
@@ -68,6 +69,7 @@ export class Dock extends Module {
         `enable alwaysShow=${this._alwaysShow}`,
         `intellihide=${this._intellihideEnabled}`,
         `showOnAllMonitors=${this._showOnAllMonitors}`,
+        `maxIconSize=${this._maxIconSize}`,
         `showTrash=${this._showTrash}`,
         `showExternalStorage=${this._showExternalStorage}`,
         `monitors=${Main.layoutManager.monitors.length}`,
@@ -139,6 +141,8 @@ export class Dock extends Module {
       () => this._handleConfigurationChange('intellihide'),
       'changed::dock-show-on-all-monitors',
       () => this._handleConfigurationChange('showOnAllMonitors'),
+      'changed::dock-icon-size',
+      () => this._handleConfigurationChange('maxIconSize'),
       'changed::dock-show-trash',
       () => this._handleConfigurationChange('showTrash'),
       'changed::dock-show-external-storage',
@@ -175,6 +179,7 @@ export class Dock extends Module {
       alwaysShow: dockSettings.get_boolean('dock-always-show'),
       intellihide: dockSettings.get_boolean('dock-intellihide'),
       showOnAllMonitors: dockSettings.get_boolean('dock-show-on-all-monitors'),
+      maxIconSize: dockSettings.get_int('dock-icon-size'),
       showTrash: dockSettings.get_boolean('dock-show-trash'),
       showExternalStorage: dockSettings.get_boolean('dock-show-external-storage'),
       motionEnabled: dockSettings.get_boolean('dock-motion-enabled'),
@@ -211,6 +216,13 @@ export class Dock extends Module {
       return;
     }
 
+    if (transition.change === 'icon-size') {
+      for (const binding of this._bindings.values()) {
+        binding.dash.setMaxIconSize(this._maxIconSize);
+      }
+      return;
+    }
+
     if (transition.change === 'motion') {
       const recipe = getBuiltInRecipe(this._motionProfile);
       for (const binding of this._bindings.values()) {
@@ -231,6 +243,7 @@ export class Dock extends Module {
     this._alwaysShow = configuration.alwaysShow;
     this._intellihideEnabled = configuration.intellihide;
     this._showOnAllMonitors = configuration.showOnAllMonitors;
+    this._maxIconSize = configuration.maxIconSize;
     this._showTrash = configuration.showTrash;
     this._showExternalStorage = configuration.showExternalStorage;
     this._motionEnabled = configuration.motionEnabled;
@@ -377,6 +390,7 @@ export class Dock extends Module {
     const dash = new AuroraDash({
       monitorIndex,
       isolateMonitor: this._showOnAllMonitors,
+      maxIconSize: this._maxIconSize,
       showTrash: this._showTrash,
       showExternalStorage: this._showExternalStorage,
     });

--- a/src/dock/dockConfiguration.ts
+++ b/src/dock/dockConfiguration.ts
@@ -2,6 +2,7 @@ export type DockConfiguration = {
   alwaysShow: boolean;
   intellihide: boolean;
   showOnAllMonitors: boolean;
+  maxIconSize: number;
   showTrash: boolean;
   showExternalStorage: boolean;
   motionEnabled: boolean;
@@ -9,7 +10,7 @@ export type DockConfiguration = {
   excludePip: boolean;
 };
 
-export type DockConfigurationChange = 'none' | 'motion' | 'pip' | 'rebuild';
+export type DockConfigurationChange = 'none' | 'icon-size' | 'motion' | 'pip' | 'rebuild';
 
 export class DockConfigurationController {
   private _snapshot: DockConfiguration;
@@ -60,6 +61,10 @@ export function classifyDockConfigurationChange(
 
   if (rebuildKeys.some((key) => previous[key] !== next[key])) {
     return 'rebuild';
+  }
+
+  if (previous.maxIconSize !== next.maxIconSize) {
+    return 'icon-size';
   }
 
   if (

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,6 +33,7 @@ export type ModuleOption = {
     | 'command-list';
   min?: number;
   max?: number;
+  resettable?: boolean;
   choices?: ModuleOptionChoice[];
 };
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -165,6 +165,22 @@ export default class AuroraShellPreferences extends ExtensionPreferences {
             page_increment: 10,
           }),
         });
+        if (option.resettable) {
+          const resetButton = new Gtk.Button({
+            icon_name: 'edit-undo-symbolic',
+            tooltip_text: _('Reset to Default'),
+            valign: Gtk.Align.CENTER,
+          });
+          resetButton.add_css_class('flat');
+
+          const syncResetButton = () => {
+            resetButton.sensitive = settings.get_user_value(option.key!) !== null;
+          };
+          resetButton.connect('clicked', () => settings.reset(option.key!));
+          settings.connect(`changed::${option.key!}`, syncResetButton);
+          syncResetButton();
+          row.add_suffix(resetButton);
+        }
         settings.bind(option.key!, row, 'value', Gio.SettingsBindFlags.DEFAULT);
         expander.add_row(row);
       } else if (option.type === 'time') {

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -3,7 +3,7 @@ import GLib from '@girs/glib-2.0';
 import Clutter from '@girs/clutter-18';
 import GObject from '@girs/gobject-2.0';
 import Shell from '@girs/shell-18';
-import type St from '@girs/st-18';
+import St from '@girs/st-18';
 import * as Main from '@girs/gnome-shell/ui/main';
 import * as DND from '@girs/gnome-shell/ui/dnd';
 import { Dash } from '@girs/gnome-shell/ui/dash';
@@ -19,6 +19,7 @@ import {
   boundsContainPoint,
   boundsEqual,
   calculateDashPlacement,
+  selectDashIconSize,
   type DashBounds,
 } from '~/shared/ui/dashLayout.ts';
 
@@ -31,6 +32,7 @@ const ANIMATION_TIME = 200;
 interface AuroraDashParams {
   monitorIndex?: number;
   isolateMonitor?: boolean;
+  maxIconSize?: number;
   showTrash?: boolean;
   showExternalStorage?: boolean;
 }
@@ -39,6 +41,7 @@ export const AuroraDash = GObject.registerClass(
   class AuroraDash extends Dash {
     declare private _monitorIndex: number;
     declare private _isolateMonitor: boolean;
+    declare private _maxIconSize: number;
     private _workArea: DashBounds | null = null;
     private _container: St.Bin | null = null;
     declare private _dashBox: St.Widget | null;
@@ -60,6 +63,7 @@ export const AuroraDash = GObject.registerClass(
       const {
         monitorIndex = Main.layoutManager.primaryIndex,
         isolateMonitor = true,
+        maxIconSize = 64,
         showTrash = false,
         showExternalStorage = false,
       } = params;
@@ -70,6 +74,7 @@ export const AuroraDash = GObject.registerClass(
 
       this._monitorIndex = monitorIndex;
       this._isolateMonitor = isolateMonitor;
+      this._maxIconSize = maxIconSize;
       this._unredirectInhibitor = new UnredirectInhibitor(global.compositor);
       this._visibility = new DashVisibilityController(this, {
         getContentActor: () => this._dashBox,
@@ -186,6 +191,13 @@ export const AuroraDash = GObject.registerClass(
       if (this._monitorIndex === index) return;
       this._monitorIndex = index;
       this._workArea = null;
+    }
+
+    setMaxIconSize(maxIconSize: number): void {
+      if (this._maxIconSize === maxIconSize) return;
+
+      this._maxIconSize = maxIconSize;
+      this._queueRedisplay();
     }
 
     get targetBox(): DashBounds | null {
@@ -462,31 +474,81 @@ export const AuroraDash = GObject.registerClass(
       if (!this._dashBox) return;
 
       const box = this._box;
-      const extraIcons = this._fixedItems.icons;
+      if (!box) return;
 
-      if (!box || extraIcons.length === 0) {
-        (Dash.prototype as any)._adjustIconSize.call(this);
-        return;
+      const dashAny = this as any;
+      const iconChildren = [...box.get_children(), ...this._fixedItems.icons].filter(
+        (actor) => actor.child?._delegate?.icon && !actor.animatingOut,
+      );
+      iconChildren.push(dashAny._showAppsIcon);
+
+      if (dashAny._maxWidth === -1 || dashAny._maxHeight === -1) return;
+
+      const themeNode = this.get_theme_node();
+      const maxAllocation = new Clutter.ActorBox({
+        x1: 0,
+        y1: 0,
+        x2: dashAny._maxWidth,
+        y2: 42,
+      });
+      const maxContent = themeNode.get_content_box(maxAllocation);
+      let availableWidth = maxContent.x2 - maxContent.x1;
+      const spacing = themeNode.get_length('spacing');
+
+      const firstButton = iconChildren[0].child;
+      const firstIcon = firstButton._delegate.icon;
+      firstIcon.icon.ensure_style();
+      const [, , iconWidth, iconHeight] = firstIcon.icon.get_preferred_size();
+      const [, , buttonWidth, buttonHeight] = firstButton.get_preferred_size();
+
+      availableWidth -=
+        iconChildren.length * (buttonWidth - iconWidth) + (iconChildren.length - 1) * spacing;
+
+      let availableHeight = dashAny._maxHeight;
+      availableHeight -= this.margin_top + this.margin_bottom;
+      availableHeight -= dashAny._background.get_theme_node().get_vertical_padding();
+      availableHeight -= themeNode.get_vertical_padding();
+      availableHeight -= buttonHeight - iconHeight;
+
+      const availableIconSize = Math.min(availableWidth / iconChildren.length, availableHeight);
+      const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+      const newIconSize = selectDashIconSize(this._maxIconSize, availableIconSize, scaleFactor);
+
+      if (newIconSize === dashAny.iconSize) return;
+
+      const oldIconSize = dashAny.iconSize;
+      dashAny.iconSize = newIconSize;
+      this.emit('icon-size-changed');
+
+      const scale = oldIconSize / newIconSize;
+      for (const child of iconChildren) {
+        const icon = child.child._delegate.icon;
+        icon.setIconSize(newIconSize);
+
+        if (
+          !Main.overview.visible ||
+          Main.overview.animationInProgress ||
+          !dashAny._shownInitially
+        ) {
+          continue;
+        }
+
+        const [targetWidth, targetHeight] = icon.icon.get_size();
+        icon.icon.set_size(icon.icon.width * scale, icon.icon.height * scale);
+        icon.icon.ease({
+          width: targetWidth,
+          height: targetHeight,
+          duration: ANIMATION_TIME,
+          mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+        });
       }
 
-      // Stock _adjustIconSize splits the available width among _box children
-      // plus the show-apps button only. The trash and external-storage icons
-      // live in _dashContainer, so their width is never counted and the dash
-      // keeps an oversized iconSize that overflows the work area. They share
-      // the DashItemContainer anatomy (child._delegate.icon) the stock filter
-      // expects, so appending them to the measured child list makes the stock
-      // math — width budget and per-icon resize — cover them too.
-      const hadOwnProp = Object.prototype.hasOwnProperty.call(box, 'get_children');
-      const origGetChildren = box.get_children;
-      box.get_children = () => [...origGetChildren.call(box), ...extraIcons];
-      try {
-        (Dash.prototype as any)._adjustIconSize.call(this);
-      } finally {
-        if (hadOwnProp) {
-          box.get_children = origGetChildren;
-        } else {
-          Reflect.deleteProperty(box, 'get_children');
-        }
+      if (dashAny._separator) {
+        dashAny._separator.ease({
+          height: newIconSize,
+          duration: ANIMATION_TIME,
+          mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+        });
       }
     }
 

--- a/src/shared/ui/dashLayout.ts
+++ b/src/shared/ui/dashLayout.ts
@@ -7,6 +7,24 @@ export interface DashBounds {
 
 export type DashPlacement = DashBounds;
 
+const DASH_ICON_SIZE_STEPS = [16, 22, 24, 32, 48, 64];
+
+export function selectDashIconSize(
+  maxIconSize: number,
+  availablePhysicalSize: number,
+  scaleFactor: number,
+): number {
+  const candidates = DASH_ICON_SIZE_STEPS.filter((size) => size < maxIconSize);
+  candidates.push(maxIconSize);
+
+  let selected = candidates[0]!;
+  for (const candidate of candidates) {
+    if (candidate * scaleFactor <= availablePhysicalSize) selected = candidate;
+  }
+
+  return selected;
+}
+
 export function boundsContainPoint(bounds: DashBounds | null, x: number, y: number): boolean {
   if (!bounds) return false;
   return (

--- a/tests/shell/dev/scenarios/dock.js
+++ b/tests/shell/dev/scenarios/dock.js
@@ -98,4 +98,50 @@ export async function exerciseDock(settings, devTool) {
   await Scripting.sleep(500);
   if (settings.get_boolean('dock-always-show') !== alwaysShowBefore)
     throw new Error('Dock toggleAlwaysShow did not restore the setting');
+
+  const originalIconSize = settings.get_user_value('dock-icon-size');
+  settings.set_int('dock-icon-size', 32);
+  await Scripting.waitLeisure();
+
+  const iconSizePanel = tool.buildPanel();
+  const iconSizeTexts = collectText(iconSizePanel);
+  iconSizePanel.destroy();
+  if (!iconSizeTexts.some((text) => text.includes('Icon size: 32px')))
+    throw new Error('Dock DevTool summary did not display the configured icon size');
+  if (!iconSizeTexts.includes('Smaller Icons') || !iconSizeTexts.includes('Larger Icons'))
+    throw new Error('Dock DevTool did not render both icon size controls');
+
+  if (!tool.decreaseIconSize()) throw new Error('Dock decreaseIconSize returned false');
+  await Scripting.waitLeisure();
+  if (settings.get_int('dock-icon-size') !== 31)
+    throw new Error('Dock decreaseIconSize did not decrease the persisted size');
+
+  if (!tool.increaseIconSize()) throw new Error('Dock increaseIconSize returned false');
+  await Scripting.waitLeisure();
+  if (settings.get_int('dock-icon-size') !== 32)
+    throw new Error('Dock increaseIconSize did not increase the persisted size');
+
+  settings.set_int('dock-icon-size', 63);
+  if (!tool.increaseIconSize()) throw new Error('Dock increaseIconSize rejected 63px');
+  if (!tool.decreaseIconSize()) throw new Error('Dock decreaseIconSize rejected 64px');
+  if (settings.get_int('dock-icon-size') !== 63)
+    throw new Error(
+      'Dock icon size controls did not preserve an unaligned value after a round trip',
+    );
+
+  settings.set_int('dock-icon-size', 16);
+  if (!tool.decreaseIconSize()) throw new Error('Dock decreaseIconSize rejected the lower bound');
+  if (settings.get_int('dock-icon-size') !== 16)
+    throw new Error('Dock decreaseIconSize crossed the 16px lower bound');
+
+  settings.set_int('dock-icon-size', 64);
+  if (!tool.increaseIconSize()) throw new Error('Dock increaseIconSize rejected the upper bound');
+  if (settings.get_int('dock-icon-size') !== 64)
+    throw new Error('Dock increaseIconSize crossed the 64px upper bound');
+
+  if (originalIconSize === null) {
+    settings.reset('dock-icon-size');
+  } else {
+    settings.set_value('dock-icon-size', originalIconSize);
+  }
 }

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -117,6 +117,10 @@ export function init() {
     'Automatic icon resize accounts for trash/storage icons outside _box',
   );
   Scripting.defineScriptEvent(
+    'configuredIconSizeApplied',
+    'Configured icon size updates every dock icon without rebuilding its binding',
+  );
+  Scripting.defineScriptEvent(
     'motionTextureSupersampled',
     'Dock motion keeps high-resolution icon textures in a normal-sized layout box',
   );
@@ -137,6 +141,7 @@ export async function run() {
   const originalAlwaysShow = settings.get_boolean('dock-always-show');
   const originalIntellihide = settings.get_boolean('dock-intellihide');
   const originalShowOnAllMonitors = settings.get_boolean('dock-show-on-all-monitors');
+  const originalIconSize = settings.get_user_value('dock-icon-size');
   const originalMotionEnabled = settings.get_boolean('dock-motion-enabled');
   const originalMotionProfile = settings.get_string('dock-motion-profile');
   const originalPipOnTop = settings.get_boolean('module-pip-on-top');
@@ -145,6 +150,7 @@ export async function run() {
   settings.set_boolean('dock-always-show', false);
   settings.set_boolean('dock-intellihide', true);
   settings.set_boolean('dock-show-on-all-monitors', false);
+  settings.set_int('dock-icon-size', 64);
   settings.set_boolean('dock-motion-enabled', true);
   settings.set_string('dock-motion-profile', 'balanced');
 
@@ -221,6 +227,39 @@ export async function run() {
     );
 
   Scripting.scriptEvent('externalStorageDisabled');
+
+  const bindingBeforeIconSizeChange = dock.bindings[0];
+  const iconSizeMaxWidth = dash._maxWidth;
+  const iconSizeMaxHeight = dash._maxHeight;
+  dash.setMaxSize(10000, 1000);
+  settings.set_int('dock-icon-size', 32);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(300);
+
+  if (dock.bindings[0] !== bindingBeforeIconSizeChange)
+    throw new Error('Changing dock-icon-size rebuilt the dock binding');
+  if (dash.iconSize !== 32)
+    throw new Error(`Configured dock icon size was not applied: ${dash.iconSize}`);
+
+  const configuredIcons = [
+    ...dash._box.get_children(),
+    dash._showAppsIcon,
+    ...dash._fixedItems.icons,
+  ]
+    .map((actor) => actor.child?._delegate?.icon)
+    .filter(Boolean);
+  if (configuredIcons.some((icon) => icon.iconSize !== 32))
+    throw new Error('Configured dock icon size was not synchronized across every icon');
+
+  settings.reset('dock-icon-size');
+  await Scripting.waitLeisure();
+  await Scripting.sleep(300);
+  if (dash.iconSize !== 64)
+    throw new Error(`Resetting dock-icon-size did not restore the 64px default: ${dash.iconSize}`);
+
+  dash.setMaxSize(iconSizeMaxWidth, iconSizeMaxHeight);
+  dash._adjustIconSize();
+  Scripting.scriptEvent('configuredIconSizeApplied');
 
   // the automatic icon resize must count the fixed dock icons (trash,
   // external storage) that live in _dashContainer outside _box. Constrain the
@@ -765,6 +804,11 @@ export async function run() {
   settings.set_boolean('dock-always-show', originalAlwaysShow);
   settings.set_boolean('dock-intellihide', originalIntellihide);
   settings.set_boolean('dock-show-on-all-monitors', originalShowOnAllMonitors);
+  if (originalIconSize === null) {
+    settings.reset('dock-icon-size');
+  } else {
+    settings.set_value('dock-icon-size', originalIconSize);
+  }
   settings.set_boolean('dock-motion-enabled', originalMotionEnabled);
   settings.set_string('dock-motion-profile', originalMotionProfile);
   settings.set_boolean('module-pip-on-top', originalPipOnTop);
@@ -789,6 +833,7 @@ let _hotAreaActiveClearShowsDock = false;
 let _dockRemoved = false;
 let _externalStorageDisabled = false;
 let _iconResizeCountsFixedIcons = false;
+let _configuredIconSizeApplied = false;
 let _motionTextureSupersampled = false;
 let _fixedIconMotionRegistered = false;
 let _externalWorkspaceActorStable = false;
@@ -861,6 +906,10 @@ export function script_iconResizeCountsFixedIcons() {
   _iconResizeCountsFixedIcons = true;
 }
 
+export function script_configuredIconSizeApplied() {
+  _configuredIconSizeApplied = true;
+}
+
 export function script_motionTextureSupersampled() {
   _motionTextureSupersampled = true;
 }
@@ -914,6 +963,8 @@ export function finish() {
     throw new Error('External storage icons were not verified disabled');
   if (!_iconResizeCountsFixedIcons)
     throw new Error('Automatic icon resize did not account for fixed dock icons');
+  if (!_configuredIconSizeApplied)
+    throw new Error('Configured icon size was not applied without rebuilding the dock');
   if (!_motionTextureSupersampled)
     throw new Error('Dock motion icon textures were not verified at high resolution');
   if (!_fixedIconMotionRegistered)

--- a/tests/unit/dock/dockConfiguration.test.ts
+++ b/tests/unit/dock/dockConfiguration.test.ts
@@ -11,6 +11,7 @@ const base: DockConfiguration = {
   alwaysShow: false,
   intellihide: false,
   showOnAllMonitors: false,
+  maxIconSize: 64,
   showTrash: true,
   showExternalStorage: true,
   motionEnabled: true,
@@ -34,6 +35,7 @@ test('dock configuration controller publishes typed snapshots and transition sco
 
 test('dock configuration distinguishes rebuild, motion and PiP updates', () => {
   assert.equal(classifyDockConfigurationChange(base, { ...base, showTrash: false }), 'rebuild');
+  assert.equal(classifyDockConfigurationChange(base, { ...base, maxIconSize: 32 }), 'icon-size');
   assert.equal(classifyDockConfigurationChange(base, { ...base, motionEnabled: false }), 'motion');
   assert.equal(classifyDockConfigurationChange(base, { ...base, excludePip: true }), 'pip');
   assert.equal(classifyDockConfigurationChange(base, { ...base }), 'none');

--- a/tests/unit/project/schema.test.ts
+++ b/tests/unit/project/schema.test.ts
@@ -234,6 +234,10 @@ test('schema — Dock defaults to the primary monitor only', () => {
   assert.equal(schemaDefault('dock-show-on-all-monitors'), 'false');
 });
 
+test('schema — Dock preserves the GNOME default maximum icon size', () => {
+  assert.equal(schemaDefault('dock-icon-size'), '64');
+});
+
 test('schema — Dock uses always auto-hide by default', () => {
   assert.equal(schemaDefault('dock-intellihide'), 'false');
 });

--- a/tests/unit/shared/ui/dashLayout.test.ts
+++ b/tests/unit/shared/ui/dashLayout.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { boundsContainPoint, boundsEqual, calculateDashPlacement } from '~/shared/ui/dashLayout.ts';
+import {
+  boundsContainPoint,
+  boundsEqual,
+  calculateDashPlacement,
+  selectDashIconSize,
+} from '~/shared/ui/dashLayout.ts';
 
 const bounds = { x: 100, y: 50, width: 800, height: 600 };
 
@@ -35,4 +40,15 @@ test('dash layout — structural bounds equality handles null', () => {
   assert.equal(boundsEqual(bounds, { ...bounds, width: 799 }), false);
   assert.equal(boundsEqual(null, null), true);
   assert.equal(boundsEqual(bounds, null), false);
+});
+
+test('dash icon size — uses the configured maximum when it fits', () => {
+  assert.equal(selectDashIconSize(40, 40, 1), 40);
+  assert.equal(selectDashIconSize(64, 128, 2), 64);
+});
+
+test('dash icon size — falls back through GNOME size steps when space is limited', () => {
+  assert.equal(selectDashIconSize(40, 31, 1), 24);
+  assert.equal(selectDashIconSize(40, 70, 2), 32);
+  assert.equal(selectDashIconSize(64, 8, 1), 16);
 });


### PR DESCRIPTION
Add a 16–64 px icon size preference with live dock updates. Preserve automatic shrinking when available space is limited. Add reset support, DevTool controls, translations, and test coverage.

Closes #100 