### PR TITLE
feat(dock): support configurable screen edges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ docs/superpowers/
 
 # IA Stuff
 .agents/
+.ua/
 skills-lock.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Aurora is split into independent modules, so you can enable only what you want.
 
 ### Dock & Panel
 
-- **Dock** - replaces the stock dash with a per-monitor dock that always auto-hides by default, with optional intellihide and always-visible modes, adjustable icon size, edge reveal, Trash, and removable drive shortcuts.
+- **Dock** - replaces the stock dash with a dock on the bottom, left, or right edge of each monitor. It auto-hides by default and supports intellihide, an always-visible mode, adaptive icon sizes, edge reveal, Trash, and removable drive shortcuts.
 - **Aurora Menu** - adds an Aurora panel menu with recent items, useful shortcuts, configurable panel icon, optional Activities button hiding, and a custom command slot.
 - **Volume Mixer** - adds per-application volume sliders to Quick Settings with fast access to Sound Settings.
 - **Low Battery Percentage** - uses GNOME's native battery percentage setting while the battery is discharging below 20%, without overriding users who already enabled it.

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aurora-shell\n"
 "Report-Msgid-Bugs-To: https://github.com/luminusOS/aurora-shell/issues\n"
-"POT-Creation-Date: 2026-08-15 17:00-0300\n"
+"POT-Creation-Date: 2026-08-16 17:56-0300\n"
 "PO-Revision-Date: 2026-07-16 09:20-0300\n"
 "Last-Translator: Aurora Shell Contributors\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -373,59 +373,79 @@ msgstr ""
 "mostra todos os aplicativos do espaço de trabalho"
 
 #: dist/dock/dock.manifest.js:33
+msgid "Dock Position"
+msgstr "Posição do dock"
+
+#: dist/dock/dock.manifest.js:34
+msgid "Screen edge where the dock appears"
+msgstr "Borda da tela onde o dock aparece"
+
+#: dist/dock/dock.manifest.js:37
+msgid "Bottom"
+msgstr "Inferior"
+
+#: dist/dock/dock.manifest.js:38
+msgid "Left"
+msgstr "Esquerda"
+
+#: dist/dock/dock.manifest.js:39
+msgid "Right"
+msgstr "Direita"
+
+#: dist/dock/dock.manifest.js:44
 msgid "Maximum Icon Size"
 msgstr "Tamanho máximo dos ícones"
 
-#: dist/dock/dock.manifest.js:35
+#: dist/dock/dock.manifest.js:46
 msgid ""
 "Maximum dock icon size in pixels (16–64); shrinks automatically when needed"
 msgstr ""
 "Tamanho máximo dos ícones da dock em pixels (16–64); reduz automaticamente "
 "quando necessário"
 
-#: dist/dock/dock.manifest.js:44
+#: dist/dock/dock.manifest.js:55
 msgid "Show Trash Icon"
 msgstr "Mostrar ícone da lixeira"
 
-#: dist/dock/dock.manifest.js:45
+#: dist/dock/dock.manifest.js:56
 msgid "Show a trash can in the dock; click to open it, right-click to empty it"
 msgstr ""
 "Mostra uma lixeira no dock; clique para abri-la e clique com o botão direito "
 "para esvaziá-la"
 
-#: dist/dock/dock.manifest.js:50
+#: dist/dock/dock.manifest.js:61
 msgid "Show External Storage"
 msgstr "Mostrar armazenamento externo"
 
-#: dist/dock/dock.manifest.js:51
+#: dist/dock/dock.manifest.js:62
 msgid "Show removable drives in the dock when they are connected"
 msgstr "Mostra unidades removíveis no dock quando estão conectadas"
 
-#: dist/dock/dock.manifest.js:56
+#: dist/dock/dock.manifest.js:67
 msgid "Icon Hover &amp; Press Effects"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:57
+#: dist/dock/dock.manifest.js:68
 msgid "Animate dock icons on hover and click"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:62
+#: dist/dock/dock.manifest.js:73
 msgid "Effect Intensity"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:63
+#: dist/dock/dock.manifest.js:74
 msgid "How strong the hover and press effects are"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:66
+#: dist/dock/dock.manifest.js:77
 msgid "Subtle"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:67
+#: dist/dock/dock.manifest.js:78
 msgid "Balanced"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:68
+#: dist/dock/dock.manifest.js:79
 msgid "Expressive"
 msgstr ""
 

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -132,6 +132,16 @@
       <summary>Show dock on all monitors</summary>
       <description>Show the dock on every eligible monitor instead of only on the primary monitor</description>
     </key>
+    <key name="dock-position" type="s">
+      <choices>
+        <choice value="bottom"/>
+        <choice value="left"/>
+        <choice value="right"/>
+      </choices>
+      <default>'bottom'</default>
+      <summary>Dock position</summary>
+      <description>Screen edge where the dock is placed</description>
+    </key>
     <key name="dock-icon-size" type="i">
       <range min="16" max="64"/>
       <default>64</default>

--- a/src/dev/dockDevTool.ts
+++ b/src/dev/dockDevTool.ts
@@ -6,6 +6,7 @@ import Clutter from '@girs/clutter-18';
 import type { SettingsManager } from '~/core/settings.ts';
 import type { Module } from '~/module.ts';
 import { Dock, type ManagedDockBinding } from '~/dock/dock.ts';
+import { DOCK_POSITIONS, type DockPosition } from '~/dock/dockConfiguration.ts';
 import { OverlapStatus } from '~/dock/intellihide.ts';
 import {
   createDevToolActionButton,
@@ -16,6 +17,16 @@ import {
 
 const MIN_ICON_SIZE = 16;
 const MAX_ICON_SIZE = 64;
+
+const POSITION_ICONS: Record<DockPosition, string> = {
+  bottom: 'go-bottom-symbolic',
+  left: 'go-first-symbolic',
+  right: 'go-last-symbolic',
+};
+
+function formatPosition(position: DockPosition): string {
+  return position.charAt(0).toUpperCase() + position.slice(1);
+}
 
 export class DockDevTool {
   readonly key = 'dock';
@@ -32,9 +43,11 @@ export class DockDevTool {
     const dock = this._getDock();
     const panel = createDevToolModulePanel();
     const iconSize = this._settings.getInt('dock-icon-size');
+    const position = this._currentPosition();
     const summary = dock
       ? [
           `Bindings: ${dock.bindings.length}`,
+          `Position: ${formatPosition(position)}`,
           `Icon size: ${iconSize}px`,
           `Always-show: ${dock.alwaysShow ? 'on' : 'off'}`,
           `Intellihide: ${dock.intellihideEnabled ? 'on' : 'off'}`,
@@ -93,6 +106,21 @@ export class DockDevTool {
     );
     panel.add_child(iconSizeRow);
 
+    const positionRow = createDevToolActionRow();
+    for (const candidate of DOCK_POSITIONS) {
+      positionRow.add_child(
+        createDevToolActionButton(
+          POSITION_ICONS[candidate],
+          candidate === position
+            ? `Position: ${formatPosition(candidate)}`
+            : formatPosition(candidate),
+          () => this.setPosition(candidate),
+          !dock || candidate === position,
+        ),
+      );
+    }
+    panel.add_child(positionRow);
+
     return panel;
   }
 
@@ -144,6 +172,26 @@ export class DockDevTool {
     this._settings.setInt('dock-icon-size', Math.min(MAX_ICON_SIZE, currentSize + 1));
     this._requestMenuRebuild();
     return true;
+  }
+
+  setPosition(position: DockPosition): boolean {
+    if (!this._getDock()) return false;
+    if (!DOCK_POSITIONS.includes(position)) return false;
+    if (position === this._currentPosition()) return false;
+
+    this._settings.setString('dock-position', position);
+    this._requestMenuRebuild();
+    return true;
+  }
+
+  cyclePosition(): boolean {
+    if (!this._getDock()) return false;
+
+    const index = DOCK_POSITIONS.indexOf(this._currentPosition());
+    const next = DOCK_POSITIONS[(index + 1) % DOCK_POSITIONS.length];
+    if (!next) return false;
+
+    return this.setPosition(next);
   }
 
   showMonitor(monitorIndex: number): boolean {
@@ -222,6 +270,11 @@ export class DockDevTool {
     const visible = binding.dash.visible ? 'visible' : 'hidden';
     const hot = binding.hotAreaActive ? ' · hot-area' : '';
     return `Monitor ${binding.monitorIndex + 1}: ${visible} · ${intellihide}${hot}`;
+  }
+
+  private _currentPosition(): DockPosition {
+    const stored = this._settings.getString('dock-position') as DockPosition;
+    return DOCK_POSITIONS.includes(stored) ? stored : 'bottom';
   }
 
   private _getDock(): Dock | null {

--- a/src/dock/dock.manifest.ts
+++ b/src/dock/dock.manifest.ts
@@ -29,6 +29,17 @@ export const manifest: ModuleManifest = {
       type: 'switch',
     },
     {
+      key: 'dock-position',
+      title: _('Dock Position'),
+      subtitle: _('Screen edge where the dock appears'),
+      type: 'select',
+      choices: [
+        { value: 'bottom', title: _('Bottom') },
+        { value: 'left', title: _('Left') },
+        { value: 'right', title: _('Right') },
+      ],
+    },
+    {
       key: 'dock-icon-size',
       title: _('Maximum Icon Size'),
       subtitle: _('Maximum dock icon size in pixels (16–64); shrinks automatically when needed'),

--- a/src/dock/dock.ts
+++ b/src/dock/dock.ts
@@ -17,12 +17,16 @@ import { getDockMonitorIndexes } from '~/dock/monitorTopology.ts';
 import { DEFAULT_PROFILE, getBuiltInRecipe } from '~/dock/motion/catalog.ts';
 import { DashMotionIntegration } from '~/dock/motion/dashMotionIntegration.ts';
 import { ContextualDragRevealCoordinator } from '~/dock/contextualDragReveal.ts';
-import { DockConfigurationController, type DockConfiguration } from '~/dock/dockConfiguration.ts';
+import {
+  DockConfigurationController,
+  type DockConfiguration,
+  type DockPosition,
+} from '~/dock/dockConfiguration.ts';
 import { ManagedDockBinding } from '~/dock/dockBinding.ts';
 export { ManagedDockBinding } from '~/dock/dockBinding.ts';
 
 const HOT_AREA_REVEAL_DURATION = 1500;
-const HOT_AREA_STRIP_HEIGHT = 1;
+const HOT_AREA_STRIP_SIZE = 1;
 const TRANSITION_ACTIVATION_COOLDOWN = 700;
 const LOG_PREFIX = 'Dock';
 
@@ -35,12 +39,12 @@ export class Dock extends Module {
   private _alwaysShow = false;
   private _intellihideEnabled = false;
   private _showOnAllMonitors = false;
+  private _position: DockPosition = 'bottom';
   private _maxIconSize = 64;
   private _showTrash = true;
   private _showExternalStorage = true;
   private _motionEnabled = true;
   private _motionProfile: string = DEFAULT_PROFILE;
-  private _excludePip = false;
   private _dragReveal: ContextualDragRevealCoordinator<ManagedDockBinding> | null = null;
   private _sessionWasLocked = false;
   private _fullscreenMonitors = new Set<number>();
@@ -69,6 +73,7 @@ export class Dock extends Module {
         `enable alwaysShow=${this._alwaysShow}`,
         `intellihide=${this._intellihideEnabled}`,
         `showOnAllMonitors=${this._showOnAllMonitors}`,
+        `position=${this._position}`,
         `maxIconSize=${this._maxIconSize}`,
         `showTrash=${this._showTrash}`,
         `showExternalStorage=${this._showExternalStorage}`,
@@ -141,6 +146,8 @@ export class Dock extends Module {
       () => this._handleConfigurationChange('intellihide'),
       'changed::dock-show-on-all-monitors',
       () => this._handleConfigurationChange('showOnAllMonitors'),
+      'changed::dock-position',
+      () => this._handleConfigurationChange('position'),
       'changed::dock-icon-size',
       () => this._handleConfigurationChange('maxIconSize'),
       'changed::dock-show-trash',
@@ -151,8 +158,6 @@ export class Dock extends Module {
       () => this._handleConfigurationChange('motionEnabled'),
       'changed::dock-motion-profile',
       () => this._handleConfigurationChange('motionProfile'),
-      'changed::module-pip-on-top',
-      () => this._handleConfigurationChange('excludePip'),
       this,
     );
 
@@ -179,12 +184,12 @@ export class Dock extends Module {
       alwaysShow: dockSettings.get_boolean('dock-always-show'),
       intellihide: dockSettings.get_boolean('dock-intellihide'),
       showOnAllMonitors: dockSettings.get_boolean('dock-show-on-all-monitors'),
+      position: dockSettings.get_string('dock-position') as DockPosition,
       maxIconSize: dockSettings.get_int('dock-icon-size'),
       showTrash: dockSettings.get_boolean('dock-show-trash'),
       showExternalStorage: dockSettings.get_boolean('dock-show-external-storage'),
       motionEnabled: dockSettings.get_boolean('dock-motion-enabled'),
       motionProfile: dockSettings.get_string('dock-motion-profile'),
-      excludePip: dockSettings.get_boolean('module-pip-on-top'),
     };
   }
 
@@ -231,24 +236,18 @@ export class Dock extends Module {
       }
       return;
     }
-
-    if (transition.change === 'pip') {
-      for (const binding of this._bindings.values()) {
-        binding.intellihide?.setExcludePipFromSmartReveal(configuration.excludePip);
-      }
-    }
   }
 
   private _applyConfigurationSnapshot(configuration: DockConfiguration): void {
     this._alwaysShow = configuration.alwaysShow;
     this._intellihideEnabled = configuration.intellihide;
     this._showOnAllMonitors = configuration.showOnAllMonitors;
+    this._position = configuration.position;
     this._maxIconSize = configuration.maxIconSize;
     this._showTrash = configuration.showTrash;
     this._showExternalStorage = configuration.showExternalStorage;
     this._motionEnabled = configuration.motionEnabled;
     this._motionProfile = configuration.motionProfile;
-    this._excludePip = configuration.excludePip;
   }
 
   get bindings(): readonly ManagedDockBinding[] {
@@ -338,7 +337,12 @@ export class Dock extends Module {
 
     const monitors: DashBounds[] = Main.layoutManager.monitors || [];
     const primaryIndex = Main.layoutManager.primaryIndex;
-    const monitorIndexes = getDockMonitorIndexes(monitors, primaryIndex, this._showOnAllMonitors);
+    const monitorIndexes = getDockMonitorIndexes(
+      monitors,
+      primaryIndex,
+      this._showOnAllMonitors,
+      this._position,
+    );
     const monitorSummary = monitors
       .map(
         (monitor, index) => `${index}:${monitor.x},${monitor.y} ${monitor.width}x${monitor.height}`,
@@ -348,6 +352,7 @@ export class Dock extends Module {
       [
         `rebuild primary=${primaryIndex}`,
         `showOnAllMonitors=${this._showOnAllMonitors}`,
+        `position=${this._position}`,
         `selected=[${monitorIndexes.join(',')}]`,
         `monitors=[${monitorSummary}]`,
       ].join(' '),
@@ -393,11 +398,12 @@ export class Dock extends Module {
       maxIconSize: this._maxIconSize,
       showTrash: this._showTrash,
       showExternalStorage: this._showExternalStorage,
+      position: this._position,
     });
     container.set_child(dash);
     dash.attachToContainer(container);
 
-    const motion = new DashMotionIntegration(getBuiltInRecipe(this._motionProfile));
+    const motion = new DashMotionIntegration(getBuiltInRecipe(this._motionProfile), this._position);
     motion.attach(dash, this._motionEnabled);
 
     const binding = new ManagedDockBinding(monitorIndex, mode, container, dash, motion);
@@ -424,7 +430,7 @@ export class Dock extends Module {
         return binding;
       }
 
-      const intellihide = new DockIntellihide(monitorIndex, this._excludePip);
+      const intellihide = new DockIntellihide(monitorIndex);
       binding.intellihide = intellihide;
       dash.setTargetBoxListener((box) => intellihide.updateTargetBox(box));
 
@@ -482,12 +488,22 @@ export class Dock extends Module {
 
   private _updateStrutFromContainer(binding: ManagedDockBinding): void {
     if (!binding.strutActor) return;
-    const h = binding.container.height;
-    if (h <= 0) return;
     const monitor = Main.layoutManager.monitors?.[binding.monitorIndex];
     if (!monitor) return;
-    binding.strutActor.set_size(monitor.width, h);
-    binding.strutActor.set_position(monitor.x, monitor.y + monitor.height - h);
+    if (this._position === 'left' || this._position === 'right') {
+      const width = binding.container.width;
+      if (width <= 0) return;
+      binding.strutActor.set_size(width, monitor.height);
+      binding.strutActor.set_position(
+        this._position === 'left' ? monitor.x : monitor.x + monitor.width - width,
+        monitor.y,
+      );
+    } else {
+      const height = binding.container.height;
+      if (height <= 0) return;
+      binding.strutActor.set_size(monitor.width, height);
+      binding.strutActor.set_position(monitor.x, monitor.y + monitor.height - height);
+    }
   }
 
   private _createHotArea(
@@ -496,14 +512,13 @@ export class Dock extends Module {
   ): InstanceType<typeof DockHotArea> | null {
     if (monitor.width <= 0 || monitor.height <= 0) return null;
 
-    const hotArea = new DockHotArea(monitor);
+    const hotArea = new DockHotArea(monitor, this._position);
     Main.layoutManager.addChrome(hotArea, {
       trackFullscreen: true,
       affectsStruts: false,
     });
 
-    hotArea.set_size(monitor.width, HOT_AREA_STRIP_HEIGHT);
-    hotArea.set_position(monitor.x, monitor.y + monitor.height - HOT_AREA_STRIP_HEIGHT);
+    this._placeHotArea(hotArea, monitor);
 
     hotArea.connectObject('triggered', () => this._revealDockFromHotArea(binding), this);
 
@@ -531,16 +546,21 @@ export class Dock extends Module {
     let bounds: DashBounds;
 
     if (this._alwaysShow) {
-      // Use physical monitor height instead of work-area height to avoid a
-      // feedback loop: our own strut shrinks the work area, which would push
-      // the dock upward on each workareas-changed signal.
       const monitor = Main.layoutManager.monitors?.[binding.monitorIndex];
-      bounds = {
-        x: workArea.x,
-        y: monitor ? monitor.y : workArea.y,
-        width: workArea.width,
-        height: monitor ? monitor.height : workArea.height,
-      };
+      bounds =
+        monitor && this._position !== 'bottom'
+          ? {
+              x: monitor.x,
+              y: workArea.y,
+              width: monitor.width,
+              height: workArea.height,
+            }
+          : {
+              x: workArea.x,
+              y: monitor ? monitor.y : workArea.y,
+              width: workArea.width,
+              height: monitor ? monitor.height : workArea.height,
+            };
     } else {
       bounds = {
         x: workArea.x,
@@ -558,9 +578,21 @@ export class Dock extends Module {
     );
 
     if (binding.hotArea) {
-      binding.hotArea.set_size(bounds.width, HOT_AREA_STRIP_HEIGHT);
-      binding.hotArea.set_position(bounds.x, bounds.y + bounds.height - HOT_AREA_STRIP_HEIGHT);
+      this._placeHotArea(binding.hotArea, bounds);
       binding.hotArea.setGeometry(bounds);
+    }
+  }
+
+  private _placeHotArea(hotArea: St.Widget, bounds: DashBounds): void {
+    if (this._position === 'left') {
+      hotArea.set_size(HOT_AREA_STRIP_SIZE, bounds.height);
+      hotArea.set_position(bounds.x, bounds.y);
+    } else if (this._position === 'right') {
+      hotArea.set_size(HOT_AREA_STRIP_SIZE, bounds.height);
+      hotArea.set_position(bounds.x + bounds.width - HOT_AREA_STRIP_SIZE, bounds.y);
+    } else {
+      hotArea.set_size(bounds.width, HOT_AREA_STRIP_SIZE);
+      hotArea.set_position(bounds.x, bounds.y + bounds.height - HOT_AREA_STRIP_SIZE);
     }
   }
 

--- a/src/dock/dockConfiguration.ts
+++ b/src/dock/dockConfiguration.ts
@@ -1,4 +1,8 @@
+export const DOCK_POSITIONS = ['bottom', 'left', 'right'] as const;
+export type DockPosition = (typeof DOCK_POSITIONS)[number];
+
 export type DockConfiguration = {
+  position: DockPosition;
   alwaysShow: boolean;
   intellihide: boolean;
   showOnAllMonitors: boolean;
@@ -7,10 +11,9 @@ export type DockConfiguration = {
   showExternalStorage: boolean;
   motionEnabled: boolean;
   motionProfile: string;
-  excludePip: boolean;
 };
 
-export type DockConfigurationChange = 'none' | 'icon-size' | 'motion' | 'pip' | 'rebuild';
+export type DockConfigurationChange = 'none' | 'icon-size' | 'motion' | 'rebuild';
 
 export class DockConfigurationController {
   private _snapshot: DockConfiguration;
@@ -40,11 +43,12 @@ export function normalizeDockConfiguration(
   value: DockConfiguration,
   changedKey?: keyof DockConfiguration,
 ): DockConfiguration {
-  if (!value.alwaysShow || !value.intellihide) return { ...value };
+  const position = DOCK_POSITIONS.includes(value.position) ? value.position : 'bottom';
+  if (!value.alwaysShow || !value.intellihide) return { ...value, position };
 
   return changedKey === 'intellihide'
-    ? { ...value, alwaysShow: false }
-    : { ...value, intellihide: false };
+    ? { ...value, position, alwaysShow: false }
+    : { ...value, position, intellihide: false };
 }
 
 export function classifyDockConfigurationChange(
@@ -52,6 +56,7 @@ export function classifyDockConfigurationChange(
   next: DockConfiguration,
 ): DockConfigurationChange {
   const rebuildKeys: Array<keyof DockConfiguration> = [
+    'position',
     'alwaysShow',
     'intellihide',
     'showOnAllMonitors',
@@ -72,10 +77,6 @@ export function classifyDockConfigurationChange(
     previous.motionProfile !== next.motionProfile
   ) {
     return 'motion';
-  }
-
-  if (previous.excludePip !== next.excludePip) {
-    return 'pip';
   }
 
   return 'none';

--- a/src/dock/externalStorageModel.ts
+++ b/src/dock/externalStorageModel.ts
@@ -11,6 +11,7 @@ export interface ExternalStorageCandidate {
   isShadowed: boolean;
   canMount: boolean;
   hasMount: boolean;
+  isRemovable: boolean;
 }
 
 export interface ExternalStorageEntry {
@@ -29,6 +30,7 @@ function isInterestingLocalStorage(candidate: ExternalStorageCandidate): boolean
   if (!candidate.id || !candidate.name) return false;
   if (candidate.isShadowed) return false;
   if (isNetworkClass(candidate.volumeClass)) return false;
+  if (!candidate.isRemovable) return false;
   if (!candidate.isNative && !candidate.hasDrive) return false;
 
   if (candidate.kind === 'volume') {

--- a/src/dock/externalStorageMonitor.ts
+++ b/src/dock/externalStorageMonitor.ts
@@ -9,6 +9,19 @@ import {
 const FALLBACK_ICON = 'drive-harddisk';
 const LOG_PREFIX = 'DockStorage';
 
+function isRemovableStorage(
+  drive: Gio.Drive | null,
+  volume: Gio.Volume | null,
+  mount: Gio.Mount | null,
+): boolean {
+  return Boolean(
+    drive?.is_removable() ||
+    drive?.is_media_removable() ||
+    volume?.can_eject() ||
+    mount?.can_eject(),
+  );
+}
+
 export interface ExternalStorageItem {
   id: string;
   name: string;
@@ -92,6 +105,7 @@ export class ExternalStorageMonitor {
     itemsById: Map<string, ExternalStorageItem>,
   ): void {
     const mount = volume.get_mount();
+    const drive = volume.get_drive();
     const root = mount ? mount.get_root() : volume.get_activation_root();
     let identifier = volume.get_uuid();
     if (!identifier) identifier = volume.get_identifier(Gio.VOLUME_IDENTIFIER_KIND_UUID);
@@ -107,11 +121,12 @@ export class ExternalStorageMonitor {
       kind: 'volume',
       sortKey: volume.get_sort_key(),
       volumeClass: volume.get_identifier(Gio.VOLUME_IDENTIFIER_KIND_CLASS),
-      hasDrive: volume.get_drive() !== null,
+      hasDrive: drive !== null,
       isNative: root ? root.is_native() : true,
       isShadowed: mount ? mount.is_shadowed() : false,
       canMount: volume.can_mount(),
       hasMount: mount !== null,
+      isRemovable: isRemovableStorage(drive, volume, mount),
     });
     itemsById.set(id, {
       id,
@@ -145,6 +160,7 @@ export class ExternalStorageMonitor {
       isShadowed: mount.is_shadowed(),
       canMount: false,
       hasMount: true,
+      isRemovable: isRemovableStorage(mount.get_drive(), null, mount),
     });
     itemsById.set(id, {
       id,

--- a/src/dock/hotArea.ts
+++ b/src/dock/hotArea.ts
@@ -14,6 +14,7 @@ import { logger } from '~/core/logger.ts';
 import { createManagedSource } from '~/core/mainLoop.ts';
 import { EdgeGestureGuard } from '~/dock/edgeGestureGuard.ts';
 import type { DashBounds } from '~/shared/ui/dash.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 
 const LOG_PREFIX = 'DockHotArea';
 const HOT_AREA_PRESSURE_THRESHOLD = 150;
@@ -32,8 +33,9 @@ export const DockHotArea = GObject.registerClass(
   },
   class DockHotArea extends St.Widget {
     declare private _pressureBarrier: Layout.PressureBarrier;
-    private _horizontalBarrier: Meta.Barrier | null = null;
+    private _edgeBarrier: Meta.Barrier | null = null;
     private _monitor!: DashBounds;
+    private _position!: DockPosition;
     private _active = true;
     private _edgeArmed = true;
     private _grabSuppressed = false;
@@ -41,11 +43,12 @@ export const DockHotArea = GObject.registerClass(
     declare private _pointerDwellTimeout: ManagedSource;
     private _gestureGuard = new EdgeGestureGuard();
 
-    override _init(monitor: DashBounds) {
+    override _init(monitor: DashBounds, position: DockPosition = 'bottom') {
       super._init({ reactive: true, visible: true, name: 'aurora-dock-hot-area' });
       this._lifecycle = new LifecycleScope();
       this._pointerDwellTimeout = createManagedSource(this._lifecycle);
       this._monitor = monitor;
+      this._position = position;
 
       this._pressureBarrier = new Layout.PressureBarrier(
         HOT_AREA_PRESSURE_THRESHOLD,
@@ -135,7 +138,7 @@ export const DockHotArea = GObject.registerClass(
 
     setGeometry(monitor: DashBounds): void {
       this._monitor = monitor;
-      if (this._active) this._rebuildBarrier(monitor.width);
+      if (this._active) this._rebuildBarrier();
     }
 
     setEnabled(enabled: boolean): void {
@@ -148,7 +151,7 @@ export const DockHotArea = GObject.registerClass(
         logger.debug(`enabled=true armed=${this._edgeArmed} geometry=${this._formatGeometry()}`, {
           prefix: LOG_PREFIX,
         });
-        this._rebuildBarrier(this._monitor.width);
+        this._rebuildBarrier();
       } else {
         this._edgeArmed = false;
         logger.debug(`enabled=false geometry=${this._formatGeometry()}`, {
@@ -187,33 +190,55 @@ export const DockHotArea = GObject.registerClass(
       super.destroy();
     }
 
-    private _rebuildBarrier(size: number): void {
+    private _rebuildBarrier(): void {
       this._destroyBarrier();
 
-      const width = Number.isFinite(size) ? size : 0;
       const left = this._monitor.x;
+      const right = left + this._monitor.width;
+      const top = this._monitor.y;
       const bottom = this._monitor.y + this._monitor.height;
 
-      if (width <= 0 || !Number.isFinite(left) || !Number.isFinite(bottom)) return;
+      if (
+        this._monitor.width <= 0 ||
+        this._monitor.height <= 0 ||
+        ![left, right, top, bottom].every(Number.isFinite)
+      )
+        return;
 
-      this._horizontalBarrier = new Meta.Barrier({
-        backend: global.backend,
-        x1: left,
-        x2: left + width,
-        y1: bottom,
-        y2: bottom,
-        directions: Meta.BarrierDirection.POSITIVE_Y,
-      });
-
-      this._pressureBarrier.addBarrier(this._horizontalBarrier);
+      const geometry =
+        this._position === 'left'
+          ? {
+              x1: left,
+              x2: left,
+              y1: top,
+              y2: bottom,
+              directions: Meta.BarrierDirection.NEGATIVE_X,
+            }
+          : this._position === 'right'
+            ? {
+                x1: right,
+                x2: right,
+                y1: top,
+                y2: bottom,
+                directions: Meta.BarrierDirection.POSITIVE_X,
+              }
+            : {
+                x1: left,
+                x2: right,
+                y1: bottom,
+                y2: bottom,
+                directions: Meta.BarrierDirection.POSITIVE_Y,
+              };
+      this._edgeBarrier = new Meta.Barrier({ backend: global.backend, ...geometry });
+      this._pressureBarrier.addBarrier(this._edgeBarrier);
     }
 
     private _destroyBarrier(): void {
-      if (!this._horizontalBarrier) return;
+      if (!this._edgeBarrier) return;
 
-      this._pressureBarrier.removeBarrier(this._horizontalBarrier);
-      this._horizontalBarrier.destroy();
-      this._horizontalBarrier = null;
+      this._pressureBarrier.removeBarrier(this._edgeBarrier);
+      this._edgeBarrier.destroy();
+      this._edgeBarrier = null;
     }
 
     private _clearDebounceTimer(): void {
@@ -251,6 +276,25 @@ export const DockHotArea = GObject.registerClass(
     }
 
     private _containsPoint(pointerX: number, pointerY: number): boolean {
+      if (this._position === 'left') {
+        const right = this._monitor.x + Math.max(1, this.width || 1);
+        return (
+          pointerX >= this._monitor.x &&
+          pointerX <= right &&
+          pointerY >= this._monitor.y &&
+          pointerY <= this._monitor.y + this._monitor.height
+        );
+      }
+      if (this._position === 'right') {
+        const right = this._monitor.x + this._monitor.width;
+        const left = right - Math.max(1, this.width || 1);
+        return (
+          pointerX >= left &&
+          pointerX <= right &&
+          pointerY >= this._monitor.y &&
+          pointerY <= this._monitor.y + this._monitor.height
+        );
+      }
       const bottom = this._monitor.y + this._monitor.height;
       const top = bottom - Math.max(1, this.height || 1);
       return (

--- a/src/dock/intellihide.ts
+++ b/src/dock/intellihide.ts
@@ -18,7 +18,6 @@ import {
   isOnActiveWorkspace,
   rectanglesOverlap,
 } from '~/dock/intellihideState.ts';
-import { isPipTitle } from '~/patches/pipWindowPolicy.ts';
 import type { DashBounds } from '~/shared/ui/dash.ts';
 
 const LOG_PREFIX = 'DockIntellihide';
@@ -75,17 +74,15 @@ export const DockIntellihide = GObject.registerClass(
     private _pendingStatus: OverlapStatus = OverlapStatus.CLEAR;
     private _pendingReason = '';
     private _pendingRectangles: Array<{ x: number; y: number; width: number; height: number }> = [];
-    private _excludePipFromSmartReveal = false;
     declare private _trackedWindowActors: Set<any>;
     declare private _trackedWindows: Set<Meta.Window>;
     declare private _queuedRefreshes: ManagedTimeoutBatch;
 
-    override _init(monitorIndex: number, excludePipFromSmartReveal = false) {
+    override _init(monitorIndex: number) {
       super._init();
       this._lifecycle = new LifecycleScope();
       this._settle = createManagedSource(this._lifecycle);
       this._monitorIndex = monitorIndex;
-      this._excludePipFromSmartReveal = excludePipFromSmartReveal;
       this._trackedWindowActors = new Set<any>();
       this._trackedWindows = new Set<Meta.Window>();
       this._queuedRefreshes = createManagedTimeoutBatch(this._lifecycle);
@@ -151,13 +148,6 @@ export const DockIntellihide = GObject.registerClass(
       this._checkOverlap(reason, force);
     }
 
-    setExcludePipFromSmartReveal(enabled: boolean): void {
-      if (this._excludePipFromSmartReveal === enabled) return;
-
-      this._excludePipFromSmartReveal = enabled;
-      this._queueRefresh('pip-smart-reveal-policy-changed', [0, 100]);
-    }
-
     destroy(): void {
       this._cancelPendingStatus();
       this._lifecycle.dispose();
@@ -189,15 +179,14 @@ export const DockIntellihide = GObject.registerClass(
 
       this._syncTrackedWindows(candidates);
       const focusedWindow = this._getFocusedCandidateWindow(candidates);
+      const descriptors = candidates.map(({ window }, index) => ({
+        rectangle: window.get_frame_rect(),
+        focused: focusedWindow === window,
+        topmost: index === candidates.length - 1,
+        fullscreen: window.is_fullscreen(),
+      }));
       const overlapState = getBlockingOverlapState(
-        candidates.map(({ window }, index) => ({
-          rectangle: window.get_frame_rect(),
-          focused: focusedWindow === window,
-          topmost: index === candidates.length - 1,
-          fullscreen: window.is_fullscreen(),
-          excludedFromSmartReveal:
-            this._excludePipFromSmartReveal && isPipTitle(window.get_title()),
-        })),
+        descriptors,
         this._targetBox,
         global.display.get_monitor_in_fullscreen(this._monitorIndex),
       );
@@ -228,8 +217,15 @@ export const DockIntellihide = GObject.registerClass(
     }
 
     private _isMonitorValid(): boolean {
+      if (this._monitorIndex < 0) return false;
+
       const monitors = Main.layoutManager.monitors || [];
-      return this._monitorIndex >= 0 && this._monitorIndex < monitors.length;
+      if (this._monitorIndex >= monitors.length) return false;
+
+      // During shutdown, the layout manager may still list a monitor that
+      // Mutter has dropped. `get_monitor_in_fullscreen` asserts against
+      // Mutter's current monitor count.
+      return this._monitorIndex < global.display.get_n_monitors();
     }
 
     private _isCandidateWindow(win: Meta.Window | null): win is Meta.Window {

--- a/src/dock/intellihideState.ts
+++ b/src/dock/intellihideState.ts
@@ -10,7 +10,6 @@ export interface OverlapCandidate {
   focused?: boolean;
   topmost?: boolean;
   fullscreen?: boolean;
-  excludedFromSmartReveal?: boolean;
 }
 
 export interface BlockingOverlapState {
@@ -48,41 +47,25 @@ export function hasOverlap(rectangles: Rectangle[], target: Rectangle): boolean 
  * on this monitor is considered. This prevents a fullscreen/maximized
  * background window from keeping the dock hidden while a small window is
  * visibly above it.
- *
- * Windows excluded from the smart-reveal exception (such as PiP) are skipped
- * while selecting that foreground window. A focused excluded window blocks
- * smart reveal unconditionally; otherwise the next eligible window underneath
- * remains authoritative. If every candidate is excluded, the dock also remains
- * hidden: an excluded foreground window must never reveal it.
- */
+ * */
 export function getBlockingOverlapState(
   candidates: OverlapCandidate[],
   target: Rectangle | null,
   monitorFullscreen: boolean,
 ): BlockingOverlapState {
-  const smartRevealCandidates = candidates.filter(
-    (candidate) => candidate.excludedFromSmartReveal !== true,
-  );
-  const focusedCandidatePreventsSmartReveal = candidates.some(
-    (candidate) => candidate.focused === true && candidate.excludedFromSmartReveal === true,
-  );
-  const focusedCandidates = smartRevealCandidates.filter((candidate) => candidate.focused === true);
+  const focusedCandidates = candidates.filter((candidate) => candidate.focused === true);
   const hasExplicitTopmostCandidate = candidates.some((candidate) => candidate.topmost === true);
-  const topmostCandidate = hasExplicitTopmostCandidate ? smartRevealCandidates.at(-1) : undefined;
+  const topmostCandidate = hasExplicitTopmostCandidate ? candidates.at(-1) : undefined;
   const blockingCandidates =
     focusedCandidates.length > 0
       ? focusedCandidates
       : topmostCandidate
         ? [topmostCandidate]
-        : smartRevealCandidates.length > 0
-          ? smartRevealCandidates
-          : candidates;
+        : candidates;
   const rectangles = blockingCandidates.map((candidate) => candidate.rectangle);
   const hasExclusiveWindow =
-    focusedCandidatePreventsSmartReveal ||
     blockingCandidates.some((candidate) => candidate.fullscreen === true) ||
-    (blockingCandidates.length === 0 && monitorFullscreen) ||
-    (candidates.length > 0 && smartRevealCandidates.length === 0);
+    (blockingCandidates.length === 0 && monitorFullscreen);
 
   return {
     blocked: hasExclusiveWindow || (target !== null && hasOverlap(rectangles, target)),

--- a/src/dock/monitorTopology.ts
+++ b/src/dock/monitorTopology.ts
@@ -1,21 +1,33 @@
 import type { DashBounds } from '~/shared/ui/dash.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 
-/**
- * Returns true if no other monitor sits directly below this one.
- * Used to avoid placing a dock between vertically stacked monitors.
- */
-export function hasDefinedBottom(monitors: DashBounds[], index: number): boolean {
+export function hasDefinedEdge(
+  monitors: DashBounds[],
+  index: number,
+  position: DockPosition,
+): boolean {
   const monitor = monitors[index];
   if (!monitor) return false;
 
-  const bottom = monitor.y + monitor.height;
   const left = monitor.x;
   const right = left + monitor.width;
+  const top = monitor.y;
+  const bottom = top + monitor.height;
 
   return !monitors.some((other, i) => {
     if (i === index) return false;
-    return other.y >= bottom && other.x < right && other.x + other.width > left;
+    const overlapsX = other.x < right && other.x + other.width > left;
+    const overlapsY = other.y < bottom && other.y + other.height > top;
+
+    if (position === 'left') return overlapsY && other.x + other.width <= left;
+    if (position === 'right') return overlapsY && other.x >= right;
+    return overlapsX && other.y >= bottom;
   });
+}
+
+/** Returns whether the bottom edge is free for a dock. */
+export function hasDefinedBottom(monitors: DashBounds[], index: number): boolean {
+  return hasDefinedEdge(monitors, index, 'bottom');
 }
 
 /**
@@ -30,10 +42,13 @@ export function getDockMonitorIndexes(
   monitors: DashBounds[],
   primaryIndex: number,
   showOnAllMonitors: boolean,
+  position: DockPosition = 'bottom',
 ): number[] {
   if (!showOnAllMonitors) {
     return primaryIndex >= 0 && primaryIndex < monitors.length ? [primaryIndex] : [];
   }
 
-  return monitors.flatMap((_monitor, index) => (hasDefinedBottom(monitors, index) ? [index] : []));
+  return monitors.flatMap((_monitor, index) =>
+    hasDefinedEdge(monitors, index, position) ? [index] : [],
+  );
 }

--- a/src/dock/motion/dashMotionIntegration.ts
+++ b/src/dock/motion/dashMotionIntegration.ts
@@ -6,6 +6,7 @@
 import type St from '@girs/st-18';
 
 import type { MotionRecipe } from '~/dock/motion/catalog.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 import { MotionSurface } from '~/dock/motion/motionSurface.ts';
 import type { AuroraDash } from '~/shared/ui/dash.ts';
 
@@ -16,7 +17,10 @@ export class DashMotionIntegration {
   private _surface: MotionSurface | null = null;
   private _recipe: MotionRecipe;
 
-  constructor(recipe: MotionRecipe) {
+  constructor(
+    recipe: MotionRecipe,
+    private _position: DockPosition,
+  ) {
     this._recipe = recipe;
   }
 
@@ -53,6 +57,7 @@ export class DashMotionIntegration {
 
     this._surface = new MotionSurface({
       recipe: this._recipe,
+      position: this._position,
       getOrderedContainers: () => {
         if (!dashContainer) return box.get_children();
         return dashContainer

--- a/src/dock/motion/iconMotionController.ts
+++ b/src/dock/motion/iconMotionController.ts
@@ -9,6 +9,7 @@ import St from '@girs/st-18';
 import Shell from '@girs/shell-18';
 
 import type { MotionRecipe } from '~/dock/motion/catalog.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 import { resolveAnimationMode } from '~/dock/motion/easing.ts';
 import { PressInteraction } from '~/dock/motion/pressInteraction.ts';
 import {
@@ -80,6 +81,7 @@ export interface IconMotionControllerParams {
   baseIcon: BaseIconLike;
   bin: St.Bin;
   recipe: MotionRecipe;
+  position: DockPosition;
   onHoverChanged?: (controller: IconMotionController, hovered: boolean) => void;
   onDestroyed?: (controller: IconMotionController) => void;
   onMeasured?: (measurement: IconBudget) => void;
@@ -90,6 +92,7 @@ export class IconMotionController {
   private _baseIcon: BaseIconLike | null;
   private _bin: St.Bin | null;
   private _recipe: MotionRecipe;
+  private _position: DockPosition;
   private _onHoverChanged: (controller: IconMotionController, hovered: boolean) => void;
   private _onDestroyed: (controller: IconMotionController) => void;
   private _onMeasured: (measurement: IconBudget) => void;
@@ -110,6 +113,7 @@ export class IconMotionController {
     baseIcon,
     bin,
     recipe,
+    position,
     onHoverChanged = () => {},
     onDestroyed = () => {},
     onMeasured = () => {},
@@ -118,6 +122,7 @@ export class IconMotionController {
     this._baseIcon = baseIcon;
     this._bin = bin;
     this._recipe = recipe;
+    this._position = position;
     this._onHoverChanged = onHoverChanged;
     this._onDestroyed = onDestroyed;
     this._onMeasured = onMeasured;
@@ -266,6 +271,7 @@ export class IconMotionController {
       animationsEnabled,
       budgetPx: budget ? budget.budgetPx : Infinity,
       iconNormalSize: budget ? budget.iconNormalSize : 0,
+      position: this._position,
     });
     // Leaving settles a little more slowly than entering. This avoids a
     // twitchy snap-back during quick pointer sweeps without delaying hover.
@@ -327,11 +333,21 @@ export class IconMotionController {
     const box = this._bin.get_allocation_box();
     const clip = clipActor.get_clip();
     if (!clip) return null;
-    const [, clipY] = clipActor.get_transformed_position();
-    const [, parentY] = parent.get_transformed_position();
+    const [clipX, clipY] = clipActor.get_transformed_position();
+    const [parentX, parentY] = parent.get_transformed_position();
+    if (this._position === 'left') {
+      const right = parentX + box.x2;
+      const clipRight = clipX + clip[0] + clip[2];
+      return { budgetPx: clipRight - right, iconNormalSize: box.x2 - box.x1 };
+    }
+    if (this._position === 'right') {
+      const left = parentX + box.x1;
+      const clipLeft = clipX + clip[0];
+      return { budgetPx: left - clipLeft, iconNormalSize: box.x2 - box.x1 };
+    }
+
     const top = parentY + box.y1;
     const clipTop = clipY + clip[1];
-
     return { budgetPx: top - clipTop, iconNormalSize: box.y2 - box.y1 };
   }
 

--- a/src/dock/motion/motionSurface.ts
+++ b/src/dock/motion/motionSurface.ts
@@ -10,6 +10,7 @@ import type Clutter from '@girs/clutter-18';
 import St from '@girs/st-18';
 
 import type { MotionRecipe } from '~/dock/motion/catalog.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 import { NeighborRadius } from '~/dock/motion/catalog.ts';
 import {
   IconMotionController,
@@ -32,6 +33,7 @@ interface SourceConnections {
 
 export class MotionSurface {
   private _recipe: MotionRecipe;
+  private _position: DockPosition;
   private _onMeasured: (measurement: IconBudget) => void;
   private _icons = new Map<MotionTarget, IconMotionController>();
   private _group: NeighborGroup | null;
@@ -39,14 +41,17 @@ export class MotionSurface {
 
   constructor({
     recipe,
+    position,
     getOrderedContainers,
     onMeasured = () => {},
   }: {
     recipe: MotionRecipe;
+    position: DockPosition;
     getOrderedContainers: () => Clutter.Actor[];
     onMeasured?: (measurement: IconBudget) => void;
   }) {
     this._recipe = recipe;
+    this._position = position;
     this._onMeasured = onMeasured;
     this._group = new NeighborGroup(getOrderedContainers);
   }
@@ -112,6 +117,7 @@ export class MotionSurface {
       baseIcon,
       bin,
       recipe: this._recipe,
+      position: this._position,
       onHoverChanged: (changed, hovered) => this._group?.setHovered(changed, hovered),
       onDestroyed: (destroyed) => {
         this._icons.delete(icon);

--- a/src/dock/motion/transforms.ts
+++ b/src/dock/motion/transforms.ts
@@ -1,8 +1,5 @@
-// Pure transform math for dock icon hover/press motion, ported from
-// d2d-companion's lib/motion/transforms.js. aurora-shell's dock only ever
-// renders at the bottom of the screen (no DockPosition concept exists
-// elsewhere in the dock code), so the orientation is hardcoded here instead
-// of being parameterized like the source project.
+// Pure dock icon hover/press transforms, ported from
+// d2d-companion's lib/motion/transforms.js and adapted for each screen edge.
 
 import {
   Easing,
@@ -12,9 +9,18 @@ import {
   type PressEffectId,
 } from '~/dock/motion/catalog.ts';
 
-// Bottom-dock orientation: icons grow upward, away from the screen edge.
-const PIVOT: readonly [number, number] = [0.5, 1];
-const OUTWARD: readonly [number, number] = [0, -1];
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
+
+const PIVOTS: Record<DockPosition, readonly [number, number]> = {
+  bottom: [0.5, 1],
+  left: [0, 0.5],
+  right: [1, 0.5],
+};
+const OUTWARD: Record<DockPosition, readonly [number, number]> = {
+  bottom: [0, -1],
+  left: [1, 0],
+  right: [-1, 0],
+};
 
 export interface IconTransform {
   scaleX: number;
@@ -37,12 +43,17 @@ interface PressTransform {
 const PRESS_SQUASH_FACTOR = 0.22;
 const PRESS_DIM_FACTOR = 0.3;
 
-export function resolvePressTransform(effect: PressEffectId, intensity: number): PressTransform {
+export function resolvePressTransform(
+  effect: PressEffectId,
+  intensity: number,
+  position: DockPosition = 'bottom',
+): PressTransform {
   const clamped = clamp(intensity, 0, 1);
   if (effect === PressEffect.DIM) return pressTransform({ dim: PRESS_DIM_FACTOR * clamped });
-  // Squash on the dock-facing (vertical) axis; the bottom dock is horizontal.
   const normalScale = 1 - PRESS_SQUASH_FACTOR * clamped;
-  return pressTransform({ scaleY: normalScale });
+  return position === 'bottom'
+    ? pressTransform({ scaleY: normalScale })
+    : pressTransform({ scaleX: normalScale });
 }
 
 export function dimOpacity(opacity: number, dim: number): number {
@@ -64,20 +75,23 @@ export function composeIconTransform({
   lift = 0,
   pressIntensity = 0,
   pressEffect = PressEffect.SQUASH,
+  position = 'bottom',
 }: {
   hoverScale?: number;
   lift?: number;
   pressIntensity?: number;
   pressEffect?: PressEffectId;
+  position?: DockPosition;
 }): IconTransform {
-  const press = resolvePressTransform(pressEffect, pressIntensity);
+  const press = resolvePressTransform(pressEffect, pressIntensity, position);
+  const outward = OUTWARD[position];
   return {
     scaleX: hoverScale * press.scaleX,
     scaleY: hoverScale * press.scaleY,
-    translationX: press.translationX,
-    translationY: OUTWARD[1] * lift + press.translationY,
+    translationX: outward[0] * lift + press.translationX,
+    translationY: outward[1] * lift + press.translationY,
     dim: press.dim,
-    pivot: PIVOT,
+    pivot: PIVOTS[position],
   };
 }
 
@@ -153,6 +167,7 @@ export function resolveIconTransform({
   animationsEnabled = true,
   budgetPx = Infinity,
   iconNormalSize = 0,
+  position = 'bottom',
 }: {
   recipe: MotionRecipe;
   hovered?: boolean;
@@ -161,9 +176,17 @@ export function resolveIconTransform({
   animationsEnabled?: boolean;
   budgetPx?: number;
   iconNormalSize?: number;
+  position?: DockPosition;
 }): IconTransform {
   if (!animationsEnabled) {
-    return { scaleX: 1, scaleY: 1, translationX: 0, translationY: 0, dim: 0, pivot: PIVOT };
+    return {
+      scaleX: 1,
+      scaleY: 1,
+      translationX: 0,
+      translationY: 0,
+      dim: 0,
+      pivot: PIVOTS[position],
+    };
   }
 
   const hoverEnabled = recipe.hover.enabled;
@@ -184,6 +207,7 @@ export function resolveIconTransform({
     lift: fitted.lift,
     pressIntensity,
     pressEffect: recipe.press.effect,
+    position,
   });
 }
 

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -6,7 +6,8 @@ import Shell from '@girs/shell-18';
 import St from '@girs/st-18';
 import * as Main from '@girs/gnome-shell/ui/main';
 import * as DND from '@girs/gnome-shell/ui/dnd';
-import { Dash } from '@girs/gnome-shell/ui/dash';
+import * as AppFavorites from '@girs/gnome-shell/ui/appFavorites';
+import { Dash, DashItemContainer } from '@girs/gnome-shell/ui/dash';
 
 import { LifecycleScope, type ManagedSource } from '~/core/lifecycleScope.ts';
 import { createManagedSource } from '~/core/mainLoop.ts';
@@ -15,10 +16,14 @@ import { DashFixedItems } from '~/shared/ui/dashFixedItems.ts';
 import { DashApplicationController } from '~/shared/ui/dashApplications.ts';
 import { DashSpringLoadCoordinator } from '~/shared/ui/dashSpringLoad.ts';
 import { DashVisibilityController } from '~/shared/ui/dashVisibility.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 import {
   boundsContainPoint,
   boundsEqual,
   calculateDashPlacement,
+  calculateDashReorderPosition,
+  isSelfReorderPosition,
+  isVerticalDock,
   selectDashIconSize,
   type DashBounds,
 } from '~/shared/ui/dashLayout.ts';
@@ -35,13 +40,24 @@ interface AuroraDashParams {
   maxIconSize?: number;
   showTrash?: boolean;
   showExternalStorage?: boolean;
+  position?: DockPosition;
 }
+
+const VerticalDragPlaceholderItem = GObject.registerClass(
+  class VerticalDragPlaceholderItem extends DashItemContainer {
+    override _init(): void {
+      super._init();
+      this.setChild(new St.Bin({ style_class: 'placeholder' }));
+    }
+  },
+);
 
 export const AuroraDash = GObject.registerClass(
   class AuroraDash extends Dash {
     declare private _monitorIndex: number;
     declare private _isolateMonitor: boolean;
     declare private _maxIconSize: number;
+    declare private _position: DockPosition;
     private _workArea: DashBounds | null = null;
     private _container: St.Bin | null = null;
     declare private _dashBox: St.Widget | null;
@@ -56,7 +72,6 @@ export const AuroraDash = GObject.registerClass(
     declare private _fixedItems: DashFixedItems;
     declare private _applications: DashApplicationController;
     declare private _unredirectInhibitor: UnredirectInhibitor;
-
     override _init(params: AuroraDashParams = {}): void {
       super._init();
 
@@ -66,6 +81,7 @@ export const AuroraDash = GObject.registerClass(
         maxIconSize = 64,
         showTrash = false,
         showExternalStorage = false,
+        position = 'bottom',
       } = params;
 
       this._lifecycle = new LifecycleScope();
@@ -75,11 +91,13 @@ export const AuroraDash = GObject.registerClass(
       this._monitorIndex = monitorIndex;
       this._isolateMonitor = isolateMonitor;
       this._maxIconSize = maxIconSize;
+      this._position = position;
       this._unredirectInhibitor = new UnredirectInhibitor(global.compositor);
       this._visibility = new DashVisibilityController(this, {
         getContentActor: () => this._dashBox,
         getContainer: () => this._container,
         getMonitorIndex: () => this._monitorIndex,
+        getPosition: () => this._position,
         getWorkArea: () => this._workArea,
         isMenuOpen: () => this._isMenuOpen(),
         applyWorkArea: (workArea) => this.applyWorkArea(workArea),
@@ -107,9 +125,21 @@ export const AuroraDash = GObject.registerClass(
       );
 
       this.set_x_align(Clutter.ActorAlign.CENTER);
-      this.set_y_align(Clutter.ActorAlign.END);
+      this.set_y_align(Clutter.ActorAlign.CENTER);
       this.set_x_expand(false);
       this.set_y_expand(false);
+      this.add_style_class_name(`dock-${position}`);
+
+      const vertical = isVerticalDock(position);
+      const containerLayout = dashContainer.layout_manager as Clutter.BoxLayout;
+      containerLayout.orientation = vertical
+        ? Clutter.Orientation.VERTICAL
+        : Clutter.Orientation.HORIZONTAL;
+      const iconsLayout = this._box.layout_manager as Clutter.BoxLayout;
+      iconsLayout.orientation = vertical
+        ? Clutter.Orientation.VERTICAL
+        : Clutter.Orientation.HORIZONTAL;
+      if (vertical) this._transposeBackgroundConstraints(dashContainer);
 
       this.connectObject('notify::allocation', () => this._queueTargetBoxUpdate(), this);
 
@@ -150,6 +180,7 @@ export const AuroraDash = GObject.registerClass(
         getContentActor: () => this._dashBox,
         getMonitorIndex: () => this._monitorIndex,
         getIsolateMonitor: () => this._isolateMonitor,
+        getPosition: () => this._position,
       });
 
       this._fixedItems = new DashFixedItems(this, this, showTrash, showExternalStorage, () => {
@@ -334,7 +365,13 @@ export const AuroraDash = GObject.registerClass(
       const width = Math.min(Math.max(prefW, 0), workArea.width);
 
       const [, prefH] = this.get_preferred_height(width || workArea.width);
-      const placement = calculateDashPlacement(workArea, prefW, prefH, this._getMarginBottom());
+      const placement = calculateDashPlacement(
+        workArea,
+        prefW,
+        prefH,
+        this._getEdgeMargin(),
+        this._position,
+      );
 
       this._container.set_size(placement.width, placement.height);
       this._container.set_position(placement.x, placement.y);
@@ -436,6 +473,13 @@ export const AuroraDash = GObject.registerClass(
       }
 
       (Dash.prototype as any)._syncLabel.call(this, item, appIcon);
+      if (appIcon && this._position !== 'bottom') {
+        appIcon._popupMenuSide = this._position === 'left' ? St.Side.RIGHT : St.Side.LEFT;
+      }
+      if (item && this._position !== 'bottom' && !item._auroraVerticalLabelPatched) {
+        item._auroraVerticalLabelPatched = true;
+        item.showLabel = () => this._showSideLabel(item);
+      }
     }
 
     override _createAppItem(app: any): any {
@@ -489,28 +533,39 @@ export const AuroraDash = GObject.registerClass(
         x1: 0,
         y1: 0,
         x2: dashAny._maxWidth,
-        y2: 42,
+        y2: dashAny._maxHeight,
       });
       const maxContent = themeNode.get_content_box(maxAllocation);
-      let availableWidth = maxContent.x2 - maxContent.x1;
       const spacing = themeNode.get_length('spacing');
-
       const firstButton = iconChildren[0].child;
       const firstIcon = firstButton._delegate.icon;
       firstIcon.icon.ensure_style();
       const [, , iconWidth, iconHeight] = firstIcon.icon.get_preferred_size();
       const [, , buttonWidth, buttonHeight] = firstButton.get_preferred_size();
 
-      availableWidth -=
-        iconChildren.length * (buttonWidth - iconWidth) + (iconChildren.length - 1) * spacing;
+      const vertical = isVerticalDock(this._position);
+      const backgroundNode = dashAny._background.get_theme_node();
 
-      let availableHeight = dashAny._maxHeight;
-      availableHeight -= this.margin_top + this.margin_bottom;
-      availableHeight -= dashAny._background.get_theme_node().get_vertical_padding();
-      availableHeight -= themeNode.get_vertical_padding();
-      availableHeight -= buttonHeight - iconHeight;
+      // The content box already excludes this actor's padding from the main axis.
+      let availableMain = vertical ? maxContent.y2 - maxContent.y1 : maxContent.x2 - maxContent.x1;
+      availableMain -=
+        iconChildren.length * (vertical ? buttonHeight - iconHeight : buttonWidth - iconWidth) +
+        (iconChildren.length - 1) * spacing;
 
-      const availableIconSize = Math.min(availableWidth / iconChildren.length, availableHeight);
+      // Start from the raw cross-axis maximum, then subtract each inset once.
+      let availableCross = vertical ? dashAny._maxWidth : dashAny._maxHeight;
+      availableCross -= vertical
+        ? this.margin_left + this.margin_right
+        : this.margin_top + this.margin_bottom;
+      availableCross -= vertical
+        ? backgroundNode.get_horizontal_padding()
+        : backgroundNode.get_vertical_padding();
+      availableCross -= vertical
+        ? themeNode.get_horizontal_padding()
+        : themeNode.get_vertical_padding();
+      availableCross -= vertical ? buttonWidth - iconWidth : buttonHeight - iconHeight;
+
+      const availableIconSize = Math.min(availableMain / iconChildren.length, availableCross);
       const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
       const newIconSize = selectDashIconSize(this._maxIconSize, availableIconSize, scaleFactor);
 
@@ -545,7 +600,8 @@ export const AuroraDash = GObject.registerClass(
 
       if (dashAny._separator) {
         dashAny._separator.ease({
-          height: newIconSize,
+          width: isVerticalDock(this._position) ? newIconSize : 1,
+          height: isVerticalDock(this._position) ? 1 : newIconSize,
           duration: ANIMATION_TIME,
           mode: Clutter.AnimationMode.EASE_OUT_QUAD,
         });
@@ -630,6 +686,7 @@ export const AuroraDash = GObject.registerClass(
       }
 
       this._applications.updateRunningDots();
+      this._syncAppSeparatorGeometry();
       this._syncLabelFlushMode();
       this._applications.installActivationOverrides();
 
@@ -665,7 +722,7 @@ export const AuroraDash = GObject.registerClass(
       const size = this._getAllocationSize();
       if (!size) return;
 
-      if (!this.visible || this.translation_y !== 0) return;
+      if (!this.visible || this.translation_x !== 0 || this.translation_y !== 0) return;
 
       const [stageX, stageY] = this.get_transformed_position();
 
@@ -684,10 +741,132 @@ export const AuroraDash = GObject.registerClass(
       this._visibility.flushPendingShow();
     }
 
-    private _getMarginBottom(): number {
+    private _getEdgeMargin(): number {
       if (this._flushMode) return 0;
+      const property =
+        this._position === 'left'
+          ? 'margin-left'
+          : this._position === 'right'
+            ? 'margin-right'
+            : 'margin-bottom';
+      return this.get_theme_node().get_length(property);
+    }
 
-      return this.get_theme_node().get_length('margin-bottom');
+    override handleDragOver(source: any, actor: any, x: number, y: number, time: number): any {
+      if (!isVerticalDock(this._position)) {
+        return (Dash.prototype as any).handleDragOver.call(this, source, actor, x, y, time);
+      }
+
+      const app = Dash.getAppFromSource(source);
+      if (!app || app.is_window_backed() || !global.settings.is_writable('favorite-apps')) {
+        return DND.DragMotionResult.NO_DROP;
+      }
+      const dashAny = this as any;
+      const favorites = AppFavorites.getAppFavorites().getFavorites();
+      const favoritePosition = favorites.indexOf(app);
+      const children = this._box.get_children();
+      const items = children.filter(
+        (child) => child !== dashAny._dragPlaceholder && child !== dashAny._separator,
+      );
+      const excludedMainAxisSize =
+        (dashAny._dragPlaceholder?.height || 0) + (dashAny._separator?.height || 0);
+      let position = calculateDashReorderPosition({
+        position: this._position,
+        pointerX: x,
+        pointerY: y,
+        childCount: items.length,
+        mainAxisSize: this._box.height,
+        excludedMainAxisSize,
+      });
+      position = Math.min(position, favorites.length);
+
+      if (isSelfReorderPosition(favoritePosition, position)) {
+        dashAny._clearDragPlaceholder();
+        return DND.DragMotionResult.CONTINUE;
+      }
+      if (position !== dashAny._dragPlaceholderPos && dashAny._animatingPlaceholdersCount === 0) {
+        const fadeIn = !dashAny._dragPlaceholder;
+        dashAny._dragPlaceholder?.destroy();
+        dashAny._dragPlaceholderPos = position;
+        dashAny._dragPlaceholder = new VerticalDragPlaceholderItem();
+        dashAny._dragPlaceholder.child.set_width(this.iconSize / 2);
+        dashAny._dragPlaceholder.child.set_height(this.iconSize);
+        this._box.insert_child_at_index(dashAny._dragPlaceholder, position);
+        dashAny._dragPlaceholder.show(fadeIn);
+      }
+      return dashAny._dragPlaceholder
+        ? DND.DragMotionResult.MOVE_DROP
+        : DND.DragMotionResult.NO_DROP;
+    }
+
+    private _transposeBackgroundConstraints(dashContainer: St.Widget): void {
+      const background = (this as any)._background as St.Widget | undefined;
+      const sizerBox = background?.get_first_child() as Clutter.Actor | null;
+      if (!background || !sizerBox) return;
+
+      // The sizer binds to the container's preferred main-axis size. Disable
+      // `y_expand` so a vertical container keeps that height instead of filling
+      // the dash.
+      dashContainer.y_expand = false;
+      dashContainer.y_align = Clutter.ActorAlign.CENTER;
+      dashContainer.x_expand = true;
+      dashContainer.x_align = Clutter.ActorAlign.FILL;
+      this._box.y_expand = false;
+      this._box.x_expand = true;
+      background.x_align = Clutter.ActorAlign.CENTER;
+
+      sizerBox.clear_constraints();
+      sizerBox.add_constraint(
+        new Clutter.BindConstraint({
+          source: this._showAppsIcon.icon,
+          coordinate: Clutter.BindCoordinate.WIDTH,
+        }),
+      );
+      sizerBox.add_constraint(
+        new Clutter.BindConstraint({
+          source: dashContainer,
+          coordinate: Clutter.BindCoordinate.HEIGHT,
+        }),
+      );
+    }
+
+    private _syncAppSeparatorGeometry(): void {
+      const separator = (this as any)._separator as St.Widget | null;
+      if (!separator) return;
+
+      if (isVerticalDock(this._position)) {
+        separator.set_height(-1); // 1px, from CSS
+        separator.set_width(this.iconSize);
+      } else {
+        separator.set_width(-1); // 1px, from CSS
+        separator.set_height(this.iconSize);
+      }
+      separator.x_align = Clutter.ActorAlign.CENTER;
+      separator.y_align = Clutter.ActorAlign.CENTER;
+      separator.x_expand = false;
+      separator.y_expand = false;
+    }
+
+    private _showSideLabel(item: any): void {
+      if (!item.label || !item._labelText) return;
+      item.label.set_text(item._labelText);
+      item.label.opacity = 0;
+      item.label.show();
+      const [stageX, stageY] = item.get_transformed_position();
+      const labelWidth = item.label.get_width();
+      const labelHeight = item.label.get_height();
+      const gap = 12;
+      const x = this._position === 'left' ? stageX + item.width + gap : stageX - labelWidth - gap;
+      const y = Math.min(
+        global.stage.height - labelHeight,
+        Math.max(0, stageY + Math.round((item.height - labelHeight) / 2)),
+      );
+      item.label.set_position(x, y);
+      item.label.ease({
+        opacity: 255,
+        duration: ANIMATION_TIME,
+        mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+      });
     }
 
     /**

--- a/src/shared/ui/dashApplications.ts
+++ b/src/shared/ui/dashApplications.ts
@@ -4,12 +4,23 @@ import type St from '@girs/st-18';
 import * as Main from '@girs/gnome-shell/ui/main';
 
 import { isDashWindowRelevant } from './dashState.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 
 type DashApplicationOptions = {
   getContentActor: () => St.Widget | null;
   getMonitorIndex: () => number;
   getIsolateMonitor: () => boolean;
+  getPosition: () => DockPosition;
 };
+
+const RUNNING_DOT_PLACEMENT = {
+  bottom: { x: Clutter.ActorAlign.CENTER, y: Clutter.ActorAlign.END, resetOffset: false },
+  left: { x: Clutter.ActorAlign.START, y: Clutter.ActorAlign.CENTER, resetOffset: true },
+  right: { x: Clutter.ActorAlign.END, y: Clutter.ActorAlign.CENTER, resetOffset: true },
+} satisfies Record<
+  DockPosition,
+  { x: Clutter.ActorAlign; y: Clutter.ActorAlign; resetOffset: boolean }
+>;
 
 export class DashApplicationController {
   constructor(private _options: DashApplicationOptions) {}
@@ -39,6 +50,8 @@ export class DashApplicationController {
   }
 
   updateRunningDots(): void {
+    const placement = RUNNING_DOT_PLACEMENT[this._options.getPosition()];
+
     for (const child of this.getChildren()) {
       const icon = child.child?._delegate;
       if (!icon?.app) continue;
@@ -48,6 +61,12 @@ export class DashApplicationController {
         .some((window: any) => this.isWindowRelevant(window));
       if (icon._dot) {
         icon._dot.visible = hasWindowHere;
+        icon._dot.x_align = placement.x;
+        icon._dot.y_align = placement.y;
+        if (placement.resetOffset) {
+          icon._dot.translation_x = 0;
+          icon._dot.translation_y = 0;
+        }
       }
     }
   }

--- a/src/shared/ui/dashFixedItems.ts
+++ b/src/shared/ui/dashFixedItems.ts
@@ -68,12 +68,8 @@ export class DashFixedItems {
     this._trash.show(false);
     this._trash.setIconSize(this._dash.iconSize);
     this._dash._hookUpLabel(this._trash);
-    const anchorIndex = container.get_children().indexOf(this._dash._showAppsIcon);
-    if (anchorIndex >= 0) {
-      container.insert_child_at_index(this._trash, anchorIndex);
-    } else {
-      container.add_child(this._trash);
-    }
+    container.add_child(this._trash);
+    this._reorder();
 
     const trash = this._trash;
     this._owner.connectObject(
@@ -112,18 +108,25 @@ export class DashFixedItems {
       icon.setIconSize(this._dash.iconSize);
       this._dash._hookUpLabel(icon);
       this._storage.push(icon);
-    }
-    const anchor = this._trash || this._dash._showAppsIcon;
-    const anchorIndex = anchor ? container.get_children().indexOf(anchor) : -1;
-
-    for (const [offset, icon] of this._storage.entries()) {
-      if (anchorIndex >= 0) {
-        container.insert_child_at_index(icon, anchorIndex + offset);
-      } else {
-        container.add_child(icon);
-      }
+      container.add_child(icon);
     }
 
+    this._reorder();
     this._onLayoutChanged();
+  }
+
+  /**
+   * Keeps `[apps] … storage, trash, showApps` in that order. Sibling-relative
+   * moves avoid the index shifts caused by moving an existing actor by index.
+   */
+  private _reorder(): void {
+    const container = this._dash._dashContainer;
+    const showAppsIcon = this._dash._showAppsIcon;
+    if (!container || !showAppsIcon) return;
+    if (container.get_children().indexOf(showAppsIcon) < 0) return;
+
+    for (const icon of this.icons) {
+      container.set_child_below_sibling(icon, showAppsIcon);
+    }
   }
 }

--- a/src/shared/ui/dashLayout.ts
+++ b/src/shared/ui/dashLayout.ts
@@ -1,3 +1,5 @@
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
+
 export interface DashBounds {
   x: number;
   y: number;
@@ -42,14 +44,67 @@ export function calculateDashPlacement(
   workArea: DashBounds,
   preferredWidth: number,
   preferredHeight: number,
-  marginBottom: number,
+  edgeMargin: number,
+  position: DockPosition = 'bottom',
 ): DashPlacement {
   const width = Math.min(Math.max(preferredWidth, 0), workArea.width);
   const height = Math.min(Math.max(preferredHeight, 0), workArea.height);
+  if (position === 'left') {
+    return {
+      x: workArea.x + edgeMargin,
+      y: workArea.y + Math.round((workArea.height - height) / 2),
+      width,
+      height,
+    };
+  }
+  if (position === 'right') {
+    return {
+      x: Math.max(workArea.x, workArea.x + workArea.width - width - edgeMargin),
+      y: workArea.y + Math.round((workArea.height - height) / 2),
+      width,
+      height,
+    };
+  }
   return {
     x: workArea.x + Math.round((workArea.width - width) / 2),
-    y: Math.max(workArea.y, workArea.y + workArea.height - height - marginBottom),
+    y: Math.max(workArea.y, workArea.y + workArea.height - height - edgeMargin),
     width,
     height,
   };
+}
+
+export function isVerticalDock(position: DockPosition): boolean {
+  return position !== 'bottom';
+}
+
+export function calculateDashReorderPosition({
+  position,
+  pointerX,
+  pointerY,
+  childCount,
+  mainAxisSize,
+  excludedMainAxisSize = 0,
+  rtl = false,
+}: {
+  position: DockPosition;
+  pointerX: number;
+  pointerY: number;
+  childCount: number;
+  mainAxisSize: number;
+  excludedMainAxisSize?: number;
+  rtl?: boolean;
+}): number {
+  const availableMainAxisSize = mainAxisSize - Math.max(0, excludedMainAxisSize);
+  if (childCount <= 0 || availableMainAxisSize <= 0) return 0;
+  const coordinate = isVerticalDock(position) ? pointerY : pointerX;
+  const forward = Math.floor((coordinate * childCount) / availableMainAxisSize);
+  const positionAlongAxis = position === 'bottom' && rtl ? childCount - forward : forward;
+  return Math.min(childCount, Math.max(0, positionAlongAxis));
+}
+
+export function isSelfReorderPosition(favoritePosition: number, targetPosition: number): boolean {
+  return (
+    favoritePosition >= 0 &&
+    (targetPosition === favoritePosition || targetPosition === favoritePosition + 1)
+  );
 }

--- a/src/shared/ui/dashVisibility.ts
+++ b/src/shared/ui/dashVisibility.ts
@@ -6,6 +6,7 @@ import * as Main from '@girs/gnome-shell/ui/main';
 import { LifecycleScope } from '~/core/lifecycleScope.ts';
 import { logger } from '~/core/logger.ts';
 import { createManagedSource } from '~/core/mainLoop.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
 
 import type { DashBounds } from './dashLayout.ts';
 import { shouldHideDash } from './dashState.ts';
@@ -15,7 +16,6 @@ const VISIBILITY_ANIMATION_TIME = 200;
 const HIDE_SCALE = 0.98;
 const EASE_DURATION_FACTOR = 0.8;
 const FULL_OPACITY = 255;
-const PIVOT_CENTER_BOTTOM: [number, number] = [0.5, 1];
 const LOG_PREFIX = 'DockDash';
 
 type VisibilityTarget = 'shown' | 'hidden';
@@ -24,6 +24,7 @@ type DashVisibilityOptions = {
   getContentActor: () => St.Widget | null;
   getContainer: () => St.Bin | null;
   getMonitorIndex: () => number;
+  getPosition: () => DockPosition;
   getWorkArea: () => DashBounds | null;
   isMenuOpen: () => boolean;
   applyWorkArea: (workArea: DashBounds) => void;
@@ -148,7 +149,7 @@ export class DashVisibilityController {
     if (this._isFullyHidden()) return;
 
     this._dash.remove_all_transitions();
-    this._dash.set_pivot_point(...PIVOT_CENTER_BOTTOM);
+    this._setEdgePivot();
 
     if (!animate) {
       this._applyHiddenState();
@@ -171,7 +172,8 @@ export class DashVisibilityController {
         });
       },
     });
-    this._dash.ease_property('translation-y', this._dash.height, {
+    const hidden = this._hiddenTranslation();
+    this._dash.ease_property(hidden.property, hidden.value, {
       duration: VISIBILITY_ANIMATION_TIME,
       mode: Clutter.AnimationMode.LINEAR,
     });
@@ -272,7 +274,7 @@ export class DashVisibilityController {
 
     const wasVisible = this._dash.visible;
     this._dash.remove_all_transitions();
-    this._dash.set_pivot_point(...PIVOT_CENTER_BOTTOM);
+    this._setEdgePivot();
 
     if (!animate) {
       this._applyShownState();
@@ -304,20 +306,24 @@ export class DashVisibilityController {
         this._flushShowCompletionCallbacks();
       },
     });
-    this._dash.ease_property('translation-y', 0, {
+    const hidden = this._hiddenTranslation();
+    this._dash.ease_property(hidden.property, 0, {
       duration: VISIBILITY_ANIMATION_TIME * EASE_DURATION_FACTOR,
       mode: Clutter.AnimationMode.LINEAR,
     });
   }
 
   private _applyShownState(): void {
+    this._dash.translation_x = 0;
     this._dash.translation_y = 0;
     this._dash.opacity = FULL_OPACITY;
     this._dash.set_scale(1, 1);
   }
 
   private _applyHiddenState(): void {
-    this._dash.translation_y = this._dash.height;
+    const hidden = this._hiddenTranslation();
+    this._dash.translation_x = hidden.property === 'translation-x' ? hidden.value : 0;
+    this._dash.translation_y = hidden.property === 'translation-y' ? hidden.value : 0;
     this._dash.opacity = 0;
     this._dash.set_scale(HIDE_SCALE, HIDE_SCALE);
   }
@@ -349,6 +355,7 @@ export class DashVisibilityController {
   private _isFullyShown(): boolean {
     return (
       this._dash.visible &&
+      this._dash.translation_x === 0 &&
       this._dash.translation_y === 0 &&
       this._dash.scale_x === 1 &&
       this._dash.scale_y === 1 &&
@@ -369,6 +376,20 @@ export class DashVisibilityController {
 
   private _setContainerInputEnabled(enabled: boolean): void {
     this._options.getContainer()?.set_reactive(enabled);
+  }
+
+  private _setEdgePivot(): void {
+    const position = this._options.getPosition();
+    if (position === 'left') this._dash.set_pivot_point(0, 0.5);
+    else if (position === 'right') this._dash.set_pivot_point(1, 0.5);
+    else this._dash.set_pivot_point(0.5, 1);
+  }
+
+  private _hiddenTranslation(): { property: 'translation-x' | 'translation-y'; value: number } {
+    const position = this._options.getPosition();
+    if (position === 'left') return { property: 'translation-x', value: -this._dash.width };
+    if (position === 'right') return { property: 'translation-x', value: this._dash.width };
+    return { property: 'translation-y', value: this._dash.height };
   }
 
   private _clearSources(): void {

--- a/src/styles/_dash.scss
+++ b/src/styles/_dash.scss
@@ -89,6 +89,57 @@
   background-color: vars.$aurora-dash-separator-color;
 }
 
+#dash.dock-left .dash-separator,
+#dash.dock-right .dash-separator {
+  height: 1px;
+  margin: 4px 0;
+}
+
+#dash.dock-left,
+#dash.dock-right {
+  padding: 6px 0;
+
+  .dash-background {
+    padding: 10px 12px;
+  }
+
+  .dash-item-container .show-apps,
+  .dash-item-container .overview-tile,
+  .dash-item-container .grid-search-result {
+    margin: 2px 0;
+    padding-bottom: 0;
+  }
+}
+
+#dash.dock-left .dash-item-container .show-apps,
+#dash.dock-left .dash-item-container .overview-tile,
+#dash.dock-left .dash-item-container .grid-search-result {
+  padding-left: 12px;
+}
+
+#dash.dock-right .dash-item-container .show-apps,
+#dash.dock-right .dash-item-container .overview-tile,
+#dash.dock-right .dash-item-container .grid-search-result {
+  padding-right: 12px;
+}
+
+#dash.dock-left .dash-background,
+#dash.dock-left .dash-separator {
+  margin-bottom: 0;
+  margin-left: 12px;
+}
+
+#dash.dock-right .dash-background,
+#dash.dock-right .dash-separator {
+  margin-bottom: 0;
+  margin-right: 12px;
+}
+
+#dash.dock-left .app-grid-running-dot,
+#dash.dock-right .app-grid-running-dot {
+  offset-y: 0;
+}
+
 #dash.flush-mode {
   margin-bottom: 0;
 
@@ -103,6 +154,32 @@
 
   .app-grid-running-dot {
     offset-y: 0;
+  }
+}
+
+#dash.dock-left.flush-mode {
+  margin-left: 0;
+
+  .dash-background,
+  .dash-separator {
+    margin-left: 0;
+  }
+
+  .dash-item-container {
+    margin: 0 12px 0 0;
+  }
+}
+
+#dash.dock-right.flush-mode {
+  margin-right: 0;
+
+  .dash-background,
+  .dash-separator {
+    margin-right: 0;
+  }
+
+  .dash-item-container {
+    margin: 0 0 0 12px;
   }
 }
 

--- a/tests/shell/dev/scenarios/dock.js
+++ b/tests/shell/dev/scenarios/dock.js
@@ -99,6 +99,51 @@ export async function exerciseDock(settings, devTool) {
   if (settings.get_boolean('dock-always-show') !== alwaysShowBefore)
     throw new Error('Dock toggleAlwaysShow did not restore the setting');
 
+  const originalPosition = settings.get_user_value('dock-position');
+  settings.set_string('dock-position', 'bottom');
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+
+  const positionPanel = tool.buildPanel();
+  const positionTexts = collectText(positionPanel);
+  positionPanel.destroy();
+  if (!positionTexts.some((text) => text.includes('Position: Bottom')))
+    throw new Error('Dock DevTool summary did not display the configured position');
+  for (const label of ['Left', 'Right'])
+    if (!positionTexts.includes(label))
+      throw new Error(`Dock DevTool did not render the ${label} position control`);
+
+  if (tool.setPosition('bottom'))
+    throw new Error('Dock setPosition re-applied the active position');
+
+  if (!tool.setPosition('left')) throw new Error('Dock setPosition returned false');
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+  if (settings.get_string('dock-position') !== 'left')
+    throw new Error('Dock setPosition did not persist the position');
+  if (getAuroraModule('dock').bindings.some((candidate) => candidate.dash._position !== 'left'))
+    throw new Error('Dock setPosition did not rebuild the dash on the new edge');
+
+  if (!tool.cyclePosition()) throw new Error('Dock cyclePosition returned false');
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+  if (settings.get_string('dock-position') !== 'right')
+    throw new Error('Dock cyclePosition did not advance to the next edge');
+
+  if (!tool.cyclePosition()) throw new Error('Dock cyclePosition wrap returned false');
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+  if (settings.get_string('dock-position') !== 'bottom')
+    throw new Error('Dock cyclePosition did not wrap back to the bottom edge');
+
+  if (originalPosition === null) {
+    settings.reset('dock-position');
+  } else {
+    settings.set_value('dock-position', originalPosition);
+  }
+  await Scripting.waitLeisure();
+  await Scripting.sleep(400);
+
   const originalIconSize = settings.get_user_value('dock-icon-size');
   settings.set_int('dock-icon-size', 32);
   await Scripting.waitLeisure();

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -2,6 +2,7 @@
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Scripting from 'resource:///org/gnome/shell/ui/scripting.js';
+import { Dash as ShellDash } from 'resource:///org/gnome/shell/ui/dash.js';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import Shell from 'gi://Shell';
@@ -16,6 +17,11 @@ import {
 import { exerciseExternalWorkspace, exerciseMonitorScope } from './scenarios/monitors.js';
 
 const DOCK_ACTOR_PREFIX = 'aurora-dock-container-';
+const RUNNING_DOT_ALIGNMENT = {
+  bottom: { x: Clutter.ActorAlign.CENTER, y: Clutter.ActorAlign.END },
+  left: { x: Clutter.ActorAlign.START, y: Clutter.ActorAlign.CENTER },
+  right: { x: Clutter.ActorAlign.END, y: Clutter.ActorAlign.CENTER },
+};
 
 function findDockActor() {
   const uiGroup = Main.layoutManager.uiGroup;
@@ -32,10 +38,343 @@ function clearIntellihideQueuedRefreshes(intellihide) {
   intellihide._settle?.clear();
 }
 
+function assertSeparatorOrientation(dash, position) {
+  const separator = dash._fixedSeparator;
+  if (!separator) return;
+
+  const [, width] = separator.get_preferred_width(-1);
+  const [, height] = separator.get_preferred_height(-1);
+  if (position === 'bottom') {
+    if (width > height) throw new Error('Bottom Dock separator is not vertical');
+    return;
+  }
+
+  if (height > width) throw new Error(`${position} Dock separator is not horizontal`);
+}
+
+function assertBackgroundCoversDash(dash, position) {
+  const background = dash._background;
+  const container = dash._dashContainer;
+  if (!background || !container) throw new Error(`${position} Dock is missing its background`);
+
+  // The background must span the container along the icon axis, otherwise it
+  // only wraps a single icon and the rest of the dock renders unpainted.
+  const [mainSize, containerMain] =
+    position === 'bottom'
+      ? [background.width, container.width]
+      : [background.height, container.height];
+
+  if (mainSize < containerMain - 1)
+    throw new Error(
+      `${position} Dock background does not span the dash ` +
+        `(background=${background.width}x${background.height}, ` +
+        `container=${container.width}x${container.height})`,
+    );
+}
+
+function assertBackgroundClearsScreenEdge(dash, position) {
+  const background = dash._background;
+  if (!background) throw new Error(`${position} Dock is missing its background`);
+
+  // The dash actor reaches the screen edge; the visible pill is inset from it
+  // by a margin on the background itself.
+  const gap =
+    position === 'left'
+      ? background.x
+      : position === 'right'
+        ? dash.width - (background.x + background.width)
+        : dash.height - (background.y + background.height);
+
+  if (gap < 8)
+    throw new Error(`${position} Dock background sits flush against the screen edge (gap=${gap})`);
+}
+
+function assertRunningDotsPointToEdge(dash, position) {
+  const expected = RUNNING_DOT_ALIGNMENT[position];
+  for (const child of dash._box.get_children()) {
+    const dot = child.child?._delegate?._dot;
+    if (!dot) continue;
+    if (dot.x_align !== expected.x || dot.y_align !== expected.y)
+      throw new Error(`${position} Dock running indicator points to the wrong edge`);
+  }
+}
+
+// The session the tests run in has no favorite apps, so no dash item owns a
+// running dot to measure. Probe the stylesheet with a throwaway widget parented
+// to the dash instead, so the `#dash.dock-*` selectors still apply.
+function assertRunningDotIsRound(dash, position) {
+  // Parented to the dash itself, not to `_dashContainer`: the container lays
+  // its children out along the icon axis, and a probe there would perturb the
+  // dock geometry the later assertions depend on.
+  const probe = new St.Widget({ style_class: 'app-grid-running-dot' });
+  dash.add_child(probe);
+  try {
+    probe.ensure_style();
+    const [, width] = probe.get_preferred_width(-1);
+    const [, height] = probe.get_preferred_height(-1);
+    if (width !== height)
+      throw new Error(`${position} Dock running indicator is not round (${width}x${height})`);
+  } finally {
+    probe.destroy();
+  }
+}
+
+// The dot must clear the icon texture, not be painted over it. The icon
+// container leaves ~18px of slack below the texture but only ~6px beside it, so
+// an offset that is right for one axis is wrong for the other.
+async function assertRunningDotClearsIcon(dash, position) {
+  const apps = Shell.AppSystem.get_default()
+    .get_installed()
+    .filter((app) => app.should_show())
+    .slice(0, 1)
+    .map((app) => app.get_id());
+  if (apps.length === 0) throw new Error('No installed app available to probe the running dot');
+
+  const saved = global.settings.get_strv('favorite-apps');
+  global.settings.set_strv('favorite-apps', apps);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(300);
+
+  try {
+    for (const child of dash._box.get_children()) {
+      const icon = child.child?._delegate;
+      const texture = icon?.icon?.icon;
+      if (!icon?._dot || !texture) continue;
+
+      const dot = icon._dot;
+      const container = icon._iconContainer;
+      // The dot is hidden while the app is not running, so it has no allocation
+      // to read; derive the free room from the container and texture boxes and
+      // compare it against the dot's size plus its offset.
+      const [containerX, containerY] = container.get_transformed_position();
+      const [textureX, textureY] = texture.get_transformed_position();
+      const slack =
+        position === 'bottom'
+          ? containerY + container.height - (textureY + texture.height)
+          : position === 'left'
+            ? textureX - containerX
+            : containerX + container.width - (textureX + texture.width);
+      const dotExtent = position === 'bottom' ? dot.height : dot.width;
+      const offset =
+        position === 'bottom'
+          ? -dot.translation_y
+          : position === 'left'
+            ? dot.translation_x
+            : -dot.translation_x;
+
+      if (offset + dotExtent > slack)
+        throw new Error(
+          `${position} Dock running indicator overlaps the icon ` +
+            `(offset=${offset}, dot=${dotExtent}, slack=${slack})`,
+        );
+    }
+  } finally {
+    global.settings.set_strv('favorite-apps', saved);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(200);
+  }
+}
+
+function assertSideLabelIsInside(dash, position) {
+  const item = dash._showAppsIcon;
+  dash._showSideLabel(item);
+  const [itemX] = item.get_transformed_position();
+
+  let labelIsInside;
+  if (position === 'left') {
+    labelIsInside = item.label.x > itemX + item.width;
+  } else if (position === 'right') {
+    labelIsInside = item.label.x + item.label.width < itemX;
+  } else {
+    throw new Error(`Side label assertion does not support ${position}`);
+  }
+
+  if (!item.label.visible || !labelIsInside)
+    throw new Error(`${position} Dock label is not shown on the inner side`);
+  item.hideLabel();
+}
+
+function assertVerticalDragPlaceholder(dash, position) {
+  const originalGetAppFromSource = ShellDash.getAppFromSource;
+  try {
+    ShellDash.getAppFromSource = () => ({ is_window_backed: () => false });
+    dash.handleDragOver({}, null, 0, dash._box.height * 0.75, 0);
+    const placeholder = dash._dragPlaceholder;
+    const hasExpectedSize =
+      placeholder?.child.width === dash.iconSize / 2 && placeholder.child.height === dash.iconSize;
+    if (!hasExpectedSize)
+      throw new Error(`${position} Dock did not create a vertical drag placeholder`);
+  } finally {
+    dash._clearDragPlaceholder();
+    ShellDash.getAppFromSource = originalGetAppFromSource;
+  }
+}
+
+function edgeIsReachable(monitors, index, position) {
+  const monitor = monitors[index];
+  const left = monitor.x;
+  const right = left + monitor.width;
+  const top = monitor.y;
+  const bottom = top + monitor.height;
+  return !monitors.some((other, otherIndex) => {
+    if (index === otherIndex) return false;
+    const overlapsX = other.x < right && other.x + other.width > left;
+    const overlapsY = other.y < bottom && other.y + other.height > top;
+    if (position === 'left') return overlapsY && other.x + other.width === left;
+    if (position === 'right') return overlapsY && other.x === right;
+    return overlapsX && other.y === bottom;
+  });
+}
+
+async function exerciseDockPositions(settings, dock) {
+  settings.set_boolean('dock-show-on-all-monitors', false);
+  settings.set_boolean('dock-always-show', false);
+  settings.set_boolean('dock-intellihide', true);
+
+  // Extent of the icon axis per position, so a side dock cannot silently pick
+  // up the bottom dock's edge offset as extra spacing between icons.
+  const iconAxisExtents = {};
+
+  for (const position of ['bottom', 'left', 'right']) {
+    settings.set_string('dock-position', position);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(350);
+
+    const binding = dock.bindings.find(
+      (candidate) => candidate.monitorIndex === Main.layoutManager.primaryIndex,
+    );
+    if (!binding || binding.dash._position !== position)
+      throw new Error(`Dock position ${position} did not apply immediately`);
+
+    const vertical = position !== 'bottom';
+    const orientation = binding.dash._dashContainer.layout_manager.orientation;
+    if ((orientation === Clutter.Orientation.VERTICAL) !== vertical)
+      throw new Error(`Dock ${position} has the wrong container orientation`);
+
+    binding.dash.show(false);
+    const workArea = Main.layoutManager.getWorkAreaForMonitor(binding.monitorIndex);
+    binding.dash.applyWorkArea(workArea);
+    await Scripting.waitLeisure();
+    const monitor = Main.layoutManager.monitors[binding.monitorIndex];
+    const container = binding.container;
+    const centerTolerance = 2;
+    if (position === 'bottom') {
+      const center = container.x + container.width / 2;
+      if (Math.abs(center - (monitor.x + monitor.width / 2)) > centerTolerance)
+        throw new Error('Bottom Dock is not centered horizontally');
+    } else {
+      const center = container.y + container.height / 2;
+      if (Math.abs(center - (workArea.y + workArea.height / 2)) > centerTolerance)
+        throw new Error(`${position} Dock is not centered vertically`);
+    }
+
+    const separator = binding.dash._fixedSeparator;
+    const children = binding.dash._dashContainer.get_children();
+    const showAppsIndex = children.indexOf(binding.dash._showAppsIcon);
+    const separatorIndex = children.indexOf(separator);
+    const firstFixedIndex = Math.min(
+      ...binding.dash._fixedItems.icons.map((icon) => children.indexOf(icon)),
+    );
+    if (separator && !(separatorIndex < firstFixedIndex && firstFixedIndex < showAppsIndex))
+      throw new Error(`${position} Dock did not keep fixed items before Show Apps`);
+
+    assertSeparatorOrientation(binding.dash, position);
+    assertBackgroundCoversDash(binding.dash, position);
+    assertBackgroundClearsScreenEdge(binding.dash, position);
+    assertRunningDotsPointToEdge(binding.dash, position);
+    assertRunningDotIsRound(binding.dash, position);
+    await assertRunningDotClearsIcon(binding.dash, position);
+
+    iconAxisExtents[position] = vertical
+      ? binding.dash._dashContainer.height
+      : binding.dash._dashContainer.width;
+
+    if (vertical) {
+      assertSideLabelIsInside(binding.dash, position);
+      assertVerticalDragPlaceholder(binding.dash, position);
+    }
+
+    if (!binding.intellihide)
+      throw new Error(`${position} Dock did not preserve intellihide after changing sides`);
+
+    binding.dash.hide(false);
+    if (position === 'left' && binding.dash.translation_x >= 0)
+      throw new Error('Left Dock did not hide toward the left edge');
+    if (position === 'right' && binding.dash.translation_x <= 0)
+      throw new Error('Right Dock did not hide toward the right edge');
+    if (position === 'bottom' && binding.dash.translation_y <= 0)
+      throw new Error('Bottom Dock did not hide toward the bottom edge');
+    binding.dash.show(false);
+
+    const hotArea = binding.hotArea;
+    if (!hotArea) throw new Error(`${position} Dock has no reveal hot area`);
+    if (vertical && (hotArea.width !== 1 || hotArea.height <= hotArea.width))
+      throw new Error(`${position} Dock hot area is not vertical`);
+    if (!vertical && (hotArea.height !== 1 || hotArea.width <= hotArea.height))
+      throw new Error('Bottom Dock hot area is not horizontal');
+
+    settings.set_boolean('dock-always-show', true);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(350);
+    const alwaysBinding = dock.bindings.find(
+      (candidate) => candidate.monitorIndex === Main.layoutManager.primaryIndex,
+    );
+    const strut = alwaysBinding?.strutActor;
+    if (!alwaysBinding || !strut) throw new Error(`${position} Dock did not create a strut`);
+    if (
+      vertical &&
+      (strut.width !== alwaysBinding.container.width || strut.height !== monitor.height)
+    )
+      throw new Error(`${position} Dock did not reserve a vertical strut`);
+    if (
+      !vertical &&
+      (strut.height !== alwaysBinding.container.height || strut.width !== monitor.width)
+    )
+      throw new Error('Bottom Dock did not reserve a horizontal strut');
+
+    settings.set_boolean('dock-always-show', false);
+    settings.set_boolean('dock-intellihide', true);
+  }
+
+  // The same icons occupy the same run length whatever edge they sit on.
+  for (const position of ['left', 'right']) {
+    const drift = Math.abs(iconAxisExtents[position] - iconAxisExtents.bottom);
+    if (drift > 4)
+      throw new Error(
+        `${position} Dock spaces its icons differently from the bottom Dock ` +
+          `(${position}=${iconAxisExtents[position]}, bottom=${iconAxisExtents.bottom})`,
+      );
+  }
+
+  settings.set_boolean('dock-show-on-all-monitors', true);
+  for (const position of ['left', 'right']) {
+    settings.set_string('dock-position', position);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(350);
+    if (
+      dock.bindings.some(
+        (candidate) =>
+          !edgeIsReachable(Main.layoutManager.monitors, candidate.monitorIndex, position),
+      )
+    )
+      throw new Error(`${position} Dock was placed on an inaccessible monitor edge`);
+  }
+
+  settings.set_boolean('dock-show-on-all-monitors', false);
+  settings.set_string('dock-position', 'bottom');
+  settings.set_boolean('dock-intellihide', true);
+  await Scripting.waitLeisure();
+  await Scripting.sleep(350);
+}
+
 export var METRICS = {};
 
 export function init() {
   Scripting.defineScriptEvent('dockPresent', 'Dock actor found in stage after enable');
+  Scripting.defineScriptEvent(
+    'dockPositionsValid',
+    'Bottom, left, and right positions apply immediately with correct geometry',
+  );
   Scripting.defineScriptEvent('panelIntact', 'Top panel still visible with dock active');
   Scripting.defineScriptEvent('trashIconValid', 'Trash icon availability and position are correct');
   Scripting.defineScriptEvent('trashClickWired', 'Trash launch behavior is valid');
@@ -83,10 +422,6 @@ export function init() {
   Scripting.defineScriptEvent(
     'intellihideFlapDebounced',
     'Transient geometry flaps coalesce into a single settled status',
-  );
-  Scripting.defineScriptEvent(
-    'pipSmartRevealPolicySynced',
-    'Intellihide follows the PiP module setting without rebuilding the Dock',
   );
   Scripting.defineScriptEvent(
     'externalWorkspaceActorStable',
@@ -141,15 +476,16 @@ export async function run() {
   const originalAlwaysShow = settings.get_boolean('dock-always-show');
   const originalIntellihide = settings.get_boolean('dock-intellihide');
   const originalShowOnAllMonitors = settings.get_boolean('dock-show-on-all-monitors');
+  const originalPosition = settings.get_string('dock-position');
   const originalIconSize = settings.get_user_value('dock-icon-size');
   const originalMotionEnabled = settings.get_boolean('dock-motion-enabled');
   const originalMotionProfile = settings.get_string('dock-motion-profile');
-  const originalPipOnTop = settings.get_boolean('module-pip-on-top');
   settings.set_boolean('dock-show-trash', true);
   settings.set_boolean('dock-show-external-storage', false);
   settings.set_boolean('dock-always-show', false);
   settings.set_boolean('dock-intellihide', true);
   settings.set_boolean('dock-show-on-all-monitors', false);
+  settings.set_string('dock-position', 'bottom');
   settings.set_int('dock-icon-size', 64);
   settings.set_boolean('dock-motion-enabled', true);
   settings.set_string('dock-motion-profile', 'balanced');
@@ -166,7 +502,7 @@ export async function run() {
   Scripting.scriptEvent('dockPresent');
 
   if (!Main.panel.visible)
-    throw new Error('Top panel is not visible — dock module may have broken it');
+    throw new Error('Top panel is not visible; the dock module may have broken it');
 
   Scripting.scriptEvent('panelIntact');
 
@@ -178,8 +514,9 @@ export async function run() {
   const showAppsIcon = dash?._showAppsIcon;
   const dashChildren = dash?._dashContainer?.get_children ? dash._dashContainer.get_children() : [];
   const showAppsIndex = dashChildren.indexOf(showAppsIcon);
-  const trashIcon = showAppsIndex > 0 ? dashChildren[showAppsIndex - 1] : null;
+  const trashIcon = dash?._fixedItems?._trash;
   const trashIndex = dashChildren.indexOf(trashIcon);
+  const fixedSeparatorIndex = dashChildren.indexOf(dash?._fixedSeparator);
   let trashUri;
   if (trashIcon && trashIcon._trashFile && trashIcon._trashFile.get_uri)
     trashUri = trashIcon._trashFile.get_uri();
@@ -197,9 +534,14 @@ export async function run() {
       throw new Error('Trash icon was not created while dock-show-trash is enabled');
     if (trashIcon._iconActor?.icon_name?.endsWith('-symbolic'))
       throw new Error(`Trash icon is still symbolic: ${trashIcon._iconActor.icon_name}`);
-    if (trashIndex < 0 || showAppsIndex !== trashIndex + 1)
+    if (
+      trashIndex < 0 ||
+      fixedSeparatorIndex < 0 ||
+      !(fixedSeparatorIndex < trashIndex && trashIndex < showAppsIndex)
+    )
       throw new Error(
-        `Trash icon must immediately precede Show Apps (trash=${trashIndex}, showApps=${showAppsIndex})`,
+        `Fixed separator and Trash must precede Show Apps ` +
+          `(separator=${fixedSeparatorIndex}, trash=${trashIndex}, showApps=${showAppsIndex})`,
       );
     if (dash._box?.contains && dash._box.contains(trashIcon))
       throw new Error('Trash icon is inside the app list instead of being a fixed dock item');
@@ -269,8 +611,8 @@ export async function run() {
   //
   // The fixed-icon count here must not depend on how many apps happen to be
   // pinned or running in the test environment: with zero of those, the dash
-  // holds only the Show Apps icon, which — being simultaneously the first
-  // and last child — picks up extra edge margin that a multi-icon dash never
+  // holds only the Show Apps icon. As both the first and last child, it picks
+  // up extra edge margin that a multi-icon dash never
   // sees, so the sizing budget below (derived from a single representative
   // icon) undershoots the real render. Synthesizing a few external-storage
   // icons (no hardware or Nautilus required) keeps the icon count, and this
@@ -338,7 +680,7 @@ export async function run() {
     const content = themeNode.get_content_box(probe);
     const horizontalChrome = 1000 - (content.x2 - content.x1);
 
-    // Budget the width for every icon at size 31 — just below the 32 step of
+    // Budget the width for every icon at size 31, just below the 32 step of
     // baseIconSizes. Counting all icons picks 24 and fits with dozens of px
     // to spare; leaving the fixed icons out of the count picks 32 and
     // overflows the budget by a full icon-step per icon.
@@ -354,7 +696,8 @@ export async function run() {
     if (natWidth > maxWidth)
       throw new Error(
         `dash natural width ${natWidth} exceeds the ${maxWidth}px budget for ` +
-          `${totalIcons} icons (iconSize=${dash.iconSize}) — fixed icons not counted`,
+          `${totalIcons} icons at iconSize=${dash.iconSize}; ` +
+          'the fixed icons may not have been counted',
       );
   } finally {
     if (injectedStorageIcons) dash._fixedItems._syncStorage([]);
@@ -436,18 +779,6 @@ export async function run() {
   Scripting.scriptEvent('itemDragKeepsDockStable');
 
   const binding = dock.bindings[0];
-
-  settings.set_boolean('module-pip-on-top', false);
-  await Scripting.waitLeisure();
-  if (binding.intellihide?._excludePipFromSmartReveal)
-    throw new Error('Intellihide kept excluding PiP after the PiP module was disabled');
-
-  settings.set_boolean('module-pip-on-top', true);
-  await Scripting.waitLeisure();
-  if (!binding.intellihide?._excludePipFromSmartReveal)
-    throw new Error('Intellihide did not exclude PiP after the PiP module was enabled');
-
-  Scripting.scriptEvent('pipSmartRevealPolicySynced');
 
   // a direct intellihide BLOCKED transition from a visible dock must hand
   // off to hover autohide. This covers switching from a small window to a
@@ -531,8 +862,8 @@ export async function run() {
   // (e.g. switching between two fullscreen/maximized windows via the dock
   // icons), the dock must stay visible while the pointer is over it and hide
   // only once the pointer leaves the dock. Retraction is driven by the dash's
-  // native hover autohide, which polls the dock actor's hover state — reliable
-  // even when the pointer moves onto a client window. This is the reported
+  // native hover autohide, which polls the dock actor's hover state and stays
+  // reliable when the pointer moves onto a client window. This is the reported
   // maximized-switch bug, where a stage motion watch never saw the exit.
   const originalBlockedDashContainerHasHover = dash._visibility._hovered;
   try {
@@ -682,7 +1013,7 @@ export async function run() {
   // intellihide flap CLEAR<->BLOCKED many times in well under a second
   // (gnome-shell-logs: rects=[0,0 0x0] then the work-area rect then the real
   // small window, all within one second). Those flaps must coalesce into a
-  // single settled status instead of toggling the dock — this covers both the
+  // single settled status instead of toggling the dock. This covers both the
   // "dock piscando / aparecendo por cima" flicker and the new-small-window
   // hides-the-dock bug.
   clearIntellihideQueuedRefreshes(binding.intellihide);
@@ -725,6 +1056,9 @@ export async function run() {
 
   clearIntellihideQueuedRefreshes(binding.intellihide);
   Scripting.scriptEvent('intellihideFlapDebounced');
+
+  await exerciseDockPositions(settings, dock);
+  Scripting.scriptEvent('dockPositionsValid');
 
   // Always auto-hide must bypass intellihide completely: with no overlap
   // decision involved, it starts hidden and only appears through the hot area.
@@ -804,6 +1138,7 @@ export async function run() {
   settings.set_boolean('dock-always-show', originalAlwaysShow);
   settings.set_boolean('dock-intellihide', originalIntellihide);
   settings.set_boolean('dock-show-on-all-monitors', originalShowOnAllMonitors);
+  settings.set_string('dock-position', originalPosition);
   if (originalIconSize === null) {
     settings.reset('dock-icon-size');
   } else {
@@ -811,13 +1146,13 @@ export async function run() {
   }
   settings.set_boolean('dock-motion-enabled', originalMotionEnabled);
   settings.set_string('dock-motion-profile', originalMotionProfile);
-  settings.set_boolean('module-pip-on-top', originalPipOnTop);
   settings.set_boolean('module-dock', originalValue);
   await Scripting.waitLeisure();
   await Scripting.sleep(300);
 }
 
 let _dockPresent = false;
+let _dockPositionsValid = false;
 let _panelIntact = false;
 let _trashIconValid = false;
 let _trashClickWired = false;
@@ -844,6 +1179,10 @@ let _dashContentDisposalSafe = false;
 
 export function script_dockPresent() {
   _dockPresent = true;
+}
+
+export function script_dockPositionsValid() {
+  _dockPositionsValid = true;
 }
 
 export function script_panelIntact() {
@@ -941,6 +1280,7 @@ export function script_dashContentDisposalSafe() {
 export function finish() {
   if (!_dockPresent)
     throw new Error('Dock actor was not found in the stage after extension enable');
+  if (!_dockPositionsValid) throw new Error('Dock side placement behavior was not verified');
   if (!_panelIntact) throw new Error('Top panel was not visible while dock was active');
   if (!_trashIconValid) throw new Error('Trash icon or its position was invalid');
   if (!_trashClickWired) throw new Error('Trash click was not wired to the open action');

--- a/tests/shell/extension.test.js
+++ b/tests/shell/extension.test.js
@@ -19,7 +19,7 @@ export async function run() {
   await Scripting.sleep(500);
 
   if (!Main.panel.visible)
-    throw new Error('Top panel is not visible — extension may have broken it');
+    throw new Error('Top panel is not visible; the extension may have broken it');
 
   // The startup overview may be visible when the extension loads in GS50.
   // Hide it first so overview.show() is not a no-op.
@@ -59,7 +59,7 @@ export function finish() {
   if (!_extensionEnabled) throw new Error('Aurora Shell extension was not found or not enabled');
 
   if (!_overviewShown)
-    throw new Error('Overview failed to show — dock or another module may have broken it');
+    throw new Error('Overview failed to show; the dock or another module may have broken it');
 
   if (!_overviewHidden) throw new Error('Overview failed to hide');
 }

--- a/tests/shell/moduleManager.test.js
+++ b/tests/shell/moduleManager.test.js
@@ -70,6 +70,6 @@ export function script_togglesComplete() {
 export function finish() {
   if (!_togglesComplete)
     throw new Error(
-      'Module toggle test did not complete — shell may have crashed during enable/disable cycle',
+      'Module toggle test did not complete; the shell may have crashed during the enable/disable cycle',
     );
 }

--- a/tests/shell/panel/bluetoothMenu/bluetoothMenu.test.js
+++ b/tests/shell/panel/bluetoothMenu/bluetoothMenu.test.js
@@ -55,8 +55,8 @@ export function finish() {
   if (!_extensionEnabled) throw new Error('Aurora Shell extension was not found or not enabled');
 
   if (!_btToggleFound)
-    throw new Error('BluetoothToggle not found — bluetooth module may not be wired up');
+    throw new Error('BluetoothToggle not found; the Bluetooth module may not be wired up');
 
   if (!_cssClassApplied)
-    throw new Error('aurora-bt-menu CSS class missing — BluetoothMenu module did not attach');
+    throw new Error('aurora-bt-menu CSS class missing; the BluetoothMenu module did not attach');
 }

--- a/tests/shell/panel/volumeMixer/volumeMixer.test.js
+++ b/tests/shell/panel/volumeMixer/volumeMixer.test.js
@@ -57,7 +57,7 @@ export async function run() {
   const slider = findOutputSlider();
 
   if (!slider) {
-    // Headless environment has no audio — verify lifecycle only
+    // The headless environment has no audio, so verify only the lifecycle.
     console.debug('[aurora-test] No OutputStreamSlider in environment; testing lifecycle only');
 
     auroraSettings.set_boolean('module-volume-mixer', false);
@@ -135,7 +135,7 @@ export function script_visibilityOk() {
 export function finish() {
   const sliderPresent = _mixerAttached || _mixerRemoved;
   if (!sliderPresent && !_lifecycleOk)
-    throw new Error('VolumeMixer module test did not complete — shell may have crashed');
+    throw new Error('VolumeMixer module test did not complete; the shell may have crashed');
   if (_mixerAttached && !_mixerRemoved)
     throw new Error('aurora-volume-mixer actor was not removed after module was disabled');
   if (_mixerAttached && !_visibilityOk)

--- a/tests/shell/patches/appSearchTooltip.test.js
+++ b/tests/shell/patches/appSearchTooltip.test.js
@@ -34,7 +34,7 @@ export async function run() {
 
   if (tooltipExistsInUiGroup())
     throw new Error(
-      `"${TOOLTIP_CSS_CLASS}" label found in Main.uiGroup at startup — should only appear on hover`,
+      `"${TOOLTIP_CSS_CLASS}" label found in Main.uiGroup at startup; it should only appear on hover`,
     );
 
   Scripting.scriptEvent('noStrayTooltip');

--- a/tests/shell/patches/iconWeave.test.js
+++ b/tests/shell/patches/iconWeave.test.js
@@ -25,7 +25,7 @@ export async function run() {
   await Scripting.waitLeisure();
   await Scripting.sleep(300);
 
-  // I19/I20 — capture patched function while module is enabled
+  // I19/I20: capture patched function while module is enabled
   const patchedFn = Shell.WindowTracker.prototype.get_window_app;
 
   auroraSettings.set_boolean('module-icon-weave', false);
@@ -37,7 +37,7 @@ export async function run() {
   if (patchedFn === restoredFn) {
     auroraSettings.set_boolean('module-icon-weave', true);
     throw new Error(
-      'Shell.WindowTracker.prototype.get_window_app was NOT restored after icon-weave disable — ' +
+      'Shell.WindowTracker.prototype.get_window_app was NOT restored after icon-weave was disabled; ' +
         'the patched function is still in place',
     );
   }
@@ -45,7 +45,7 @@ export async function run() {
   Scripting.scriptEvent('prototypePatched');
   Scripting.scriptEvent('prototypeRestored');
 
-  // Re-enable and verify it patches again (I19 — no crash on re-enable)
+  // Re-enable and verify I19: re-enabling must not crash.
   auroraSettings.set_boolean('module-icon-weave', true);
   await Scripting.waitLeisure();
   await Scripting.sleep(200);

--- a/tests/shell/patches/noOverview.test.js
+++ b/tests/shell/patches/noOverview.test.js
@@ -67,11 +67,11 @@ export function script_overviewHiddenManually() {
 }
 
 export function finish() {
-  // overviewHiddenAtStartup is informational in GS50 — not required.
+  // overviewHiddenAtStartup is informational and not required in GS50.
 
   if (!_hasOverviewRestored)
     throw new Error(
-      'sessionMode.hasOverview was not restored after startup — overview may be permanently disabled',
+      'sessionMode.hasOverview was not restored after startup; overview may be permanently disabled',
     );
 
   if (!_overviewShownManually) throw new Error('Overview cannot be shown manually after startup');

--- a/tests/shell/privacy/dndOnShare.test.js
+++ b/tests/shell/privacy/dndOnShare.test.js
@@ -19,7 +19,7 @@ export function init() {
   );
   Scripting.defineScriptEvent(
     'indicatorNotFound',
-    'Screen sharing indicator not available — skipping live test',
+    'Skipping live test because the screen sharing indicator is unavailable',
   );
 }
 
@@ -42,7 +42,7 @@ export async function run() {
 
   if (!indicator) {
     console.debug(
-      '[aurora-test] Screen sharing indicator not found — skipping live DND toggle test',
+      '[aurora-test] Skipping live DND toggle test because no screen sharing indicator was found',
     );
     Scripting.scriptEvent('indicatorNotFound');
 
@@ -96,7 +96,7 @@ export function script_dndRestored() {
 
 export function finish() {
   if (_indicatorNotFound) {
-    // Graceful skip — the test environment doesn't have a screen sharing indicator.
+    // Skip gracefully because the test environment has no screen sharing indicator.
     console.debug('[aurora-test] DND live test skipped (no indicator in this environment)');
     return;
   }

--- a/tests/shell/privacy/privacyPanel.test.js
+++ b/tests/shell/privacy/privacyPanel.test.js
@@ -23,7 +23,7 @@ export function init() {
   );
   Scripting.defineScriptEvent(
     'indicatorNotFound',
-    'Screen sharing indicator not available — skipping live test',
+    'Skipping live test because the screen sharing indicator is unavailable',
   );
 }
 
@@ -36,7 +36,9 @@ export async function run() {
   const indicator = statusArea.screenSharing || statusArea.quickSettings?._remoteAccess;
 
   if (!indicator) {
-    console.debug('[aurora-test] No screen sharing indicator — skipping live PrivacyPanel test');
+    console.debug(
+      '[aurora-test] Skipping live PrivacyPanel test because no screen sharing indicator was found',
+    );
     Scripting.scriptEvent('indicatorNotFound');
 
     // Verify module left panel untouched

--- a/tests/shell/support/testUtils.js
+++ b/tests/shell/support/testUtils.js
@@ -18,7 +18,7 @@ export function getAuroraSettings() {
   const ext = Main.extensionManager.lookup(EXTENSION_UUID);
   if (!ext) throw new Error(`Extension ${EXTENSION_UUID} not found`);
   if (!ext.stateObj)
-    throw new Error(`Extension ${EXTENSION_UUID} has no state object — not fully loaded`);
+    throw new Error(`Extension ${EXTENSION_UUID} has no state object and may not be fully loaded`);
 
   // Delegate to the extension's own getSettings() so that the same schema
   // source used by the extension itself is used here. This avoids issues

--- a/tests/unit/core/lifecycleScope.test.ts
+++ b/tests/unit/core/lifecycleScope.test.ts
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 
 import { LifecycleScope } from '~/core/lifecycleScope.ts';
 
-test('LifecycleScope — runs teardown in reverse order and is idempotent', () => {
+test('LifecycleScope: runs teardown in reverse order and is idempotent', () => {
   const calls: number[] = [];
   const scope = new LifecycleScope();
   scope.onDispose(() => calls.push(1));
@@ -14,7 +14,7 @@ test('LifecycleScope — runs teardown in reverse order and is idempotent', () =
   assert.deepEqual(calls, [3, 2, 1]);
 });
 
-test('LifecycleScope — disconnects signals', () => {
+test('LifecycleScope: disconnects signals', () => {
   const disconnected: number[] = [];
   const target = {
     connect: () => 42,
@@ -27,7 +27,7 @@ test('LifecycleScope — disconnects signals', () => {
   assert.deepEqual(disconnected, [42]);
 });
 
-test('LifecycleScope — replaces and clears a managed source', () => {
+test('LifecycleScope: replaces and clears a managed source', () => {
   const removed: number[] = [];
   const scope = new LifecycleScope();
   const source = scope.manageSource((id) => removed.push(id));
@@ -43,7 +43,7 @@ test('LifecycleScope — replaces and clears a managed source', () => {
   assert.deepEqual(removed, [1, 2]);
 });
 
-test('LifecycleScope — removes the previous source before creating its replacement', () => {
+test('LifecycleScope: removes the previous source before creating its replacement', () => {
   const events: string[] = [];
   const scope = new LifecycleScope();
   const source = scope.manageSource((id) => events.push(`remove:${id}`));
@@ -60,7 +60,7 @@ test('LifecycleScope — removes the previous source before creating its replace
   assert.deepEqual(events, ['create:1', 'remove:1', 'create:2']);
 });
 
-test('LifecycleScope — completes a managed source without removing it', () => {
+test('LifecycleScope: completes a managed source without removing it', () => {
   const removed: number[] = [];
   const scope = new LifecycleScope();
   const source = scope.manageSource((id) => removed.push(id));
@@ -73,7 +73,7 @@ test('LifecycleScope — completes a managed source without removing it', () => 
   assert.deepEqual(removed, []);
 });
 
-test('LifecycleScope — disposes an active managed source', () => {
+test('LifecycleScope: disposes an active managed source', () => {
   const removed: number[] = [];
   const scope = new LifecycleScope();
   const source = scope.manageSource((id) => removed.push(id));
@@ -85,7 +85,7 @@ test('LifecycleScope — disposes an active managed source', () => {
   assert.deepEqual(removed, [9]);
 });
 
-test('LifecycleScope — disposes every active source in reverse registration order', () => {
+test('LifecycleScope: disposes every active source in reverse registration order', () => {
   const removed: number[] = [];
   const scope = new LifecycleScope();
   const first = scope.manageSource((id) => removed.push(id));
@@ -98,7 +98,7 @@ test('LifecycleScope — disposes every active source in reverse registration or
   assert.deepEqual(removed, [2, 1]);
 });
 
-test('LifecycleScope — remains idempotent when a source remover reenters dispose', () => {
+test('LifecycleScope: remains idempotent when a source remover reenters dispose', () => {
   const events: string[] = [];
   const scope = new LifecycleScope();
   const source = scope.manageSource((id) => {
@@ -114,7 +114,7 @@ test('LifecycleScope — remains idempotent when a source remover reenters dispo
   assert.deepEqual(events, ['remove:5', 'teardown']);
 });
 
-test('LifecycleScope — does not create a managed source after disposal', () => {
+test('LifecycleScope: does not create a managed source after disposal', () => {
   const removed: number[] = [];
   let created = false;
   const scope = new LifecycleScope();
@@ -131,7 +131,7 @@ test('LifecycleScope — does not create a managed source after disposal', () =>
   assert.deepEqual(removed, []);
 });
 
-test('LifecycleScope — teardown registered after disposal runs immediately', () => {
+test('LifecycleScope: teardown registered after disposal runs immediately', () => {
   let tornDown = false;
   const scope = new LifecycleScope();
   scope.dispose();

--- a/tests/unit/desktop/trayIcons/appIdentity.test.ts
+++ b/tests/unit/desktop/trayIcons/appIdentity.test.ts
@@ -3,14 +3,14 @@ import { test } from 'node:test';
 
 import { appIdCandidates, sniIdentityMatchesAppId } from '~/desktop/trayIcons/appIdentity.ts';
 
-test('app identity — keeps suffixed and unsuffixed lowercase candidates', () => {
+test('app identity: keeps suffixed and unsuffixed lowercase candidates', () => {
   assert.deepEqual(
     appIdCandidates(['Org.Example.App.desktop']),
     new Set(['org.example.app.desktop', 'org.example.app']),
   );
 });
 
-test('app identity — matches specific SNI metadata without generic component collisions', () => {
+test('app identity: matches specific SNI metadata without generic component collisions', () => {
   assert.equal(
     sniIdentityMatchesAppId(
       { desktopEntry: 'com.discordapp.Discord.desktop', sniId: '' },
@@ -24,14 +24,14 @@ test('app identity — matches specific SNI metadata without generic component c
   );
 });
 
-test('app identity — combines candidates from Shell and background-app IDs', () => {
+test('app identity: combines candidates from Shell and background-app IDs', () => {
   assert.deepEqual(
     appIdCandidates(['org.example.App', 'Com.Vendor.App.desktop']),
     new Set(['org.example.app', 'com.vendor.app.desktop', 'com.vendor.app']),
   );
 });
 
-test('app identity — ignores empty IDs and deduplicates equivalent forms', () => {
+test('app identity: ignores empty IDs and deduplicates equivalent forms', () => {
   assert.deepEqual(
     appIdCandidates(['', 'app.desktop', 'APP.desktop']),
     new Set(['app.desktop', 'app']),

--- a/tests/unit/desktop/trayIcons/trayState.test.ts
+++ b/tests/unit/desktop/trayIcons/trayState.test.ts
@@ -61,7 +61,7 @@ test('addAttention and clearAttention manage Set membership', () => {
   assert.ok(state.attentionIds.has('item-2'));
 });
 
-test('TrayItem interface — optional fields are optional', () => {
+test('TrayItem interface: optional fields are optional', () => {
   const item: TrayItem = {
     id: 'test-item',
     icon: 'application-symbolic',

--- a/tests/unit/device/runtime.test.ts
+++ b/tests/unit/device/runtime.test.ts
@@ -30,14 +30,14 @@ const monitor = (values: Partial<MonitorInput> = {}): MonitorInput => ({
   ...values,
 });
 
-test('device runtime — orientation is based on logical dimensions', () => {
+test('device runtime: orientation is based on logical dimensions', () => {
   assert.equal(classifyOrientation(1080, 1920), 'portrait');
   assert.equal(classifyOrientation(1920, 1080), 'landscape');
   assert.equal(classifyOrientation(800, 800), 'square');
   assert.equal(classifyOrientation(0, 800), 'unknown');
 });
 
-test('device runtime — input mode reports mixed devices honestly', () => {
+test('device runtime: input mode reports mixed devices honestly', () => {
   assert.equal(classifyInputMode(input({ touch: true })), 'touch');
   assert.equal(classifyInputMode(input({ pointer: true })), 'pointer');
   assert.equal(classifyInputMode(input({ keyboard: true })), 'keyboard');
@@ -45,7 +45,7 @@ test('device runtime — input mode reports mixed devices honestly', () => {
   assert.equal(classifyInputMode(input()), 'unknown');
 });
 
-test('device runtime — classifies phone, tablet, laptop, desktop and unknown', () => {
+test('device runtime: classifies phone, tablet, laptop, desktop and unknown', () => {
   assert.equal(
     classifyDevice([monitor({ width: 412, height: 892 })], input({ touch: true })),
     'phone',
@@ -62,7 +62,7 @@ test('device runtime — classifies phone, tablet, laptop, desktop and unknown',
   assert.equal(classifyDevice([], input()), 'unknown');
 });
 
-test('device runtime — mixed phone topology assigns mobile internal and desktop external roles', () => {
+test('device runtime: mixed phone topology assigns mobile internal and desktop external roles', () => {
   const snapshot = createDeviceSnapshot(
     [
       monitor({ width: 412, height: 892 }),
@@ -79,7 +79,7 @@ test('device runtime — mixed phone topology assigns mobile internal and deskto
   assert.deepEqual([...activeDisplayRoles(snapshot)].sort(), ['desktop', 'mobile']);
 });
 
-test('device runtime — mobile-only topology retains desktop fallback for current modules', () => {
+test('device runtime: mobile-only topology retains desktop fallback for current modules', () => {
   const snapshot = createDeviceSnapshot(
     [monitor({ width: 412, height: 892 })],
     input({ touch: true }),
@@ -89,7 +89,7 @@ test('device runtime — mobile-only topology retains desktop fallback for curre
   assert.deepEqual([...activeDisplayRoles(snapshot, false)], ['mobile']);
 });
 
-test('device runtime — equality detects meaningful topology changes only', () => {
+test('device runtime: equality detects meaningful topology changes only', () => {
   const first = createDeviceSnapshot([monitor()], input({ keyboard: true }), new Set());
   const same = createDeviceSnapshot([monitor()], input({ keyboard: true }), new Set());
   const changed = createDeviceSnapshot(

--- a/tests/unit/dock/dashLayout.test.ts
+++ b/tests/unit/dock/dashLayout.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  calculateDashPlacement,
+  calculateDashReorderPosition,
+  isSelfReorderPosition,
+  selectDashIconSize,
+} from '~/shared/ui/dashLayout.ts';
+
+const workArea = { x: 100, y: 50, width: 1000, height: 700 };
+
+test('dash placement centers the dock along each selected edge', () => {
+  assert.deepEqual(calculateDashPlacement(workArea, 400, 80, 10, 'bottom'), {
+    x: 400,
+    y: 660,
+    width: 400,
+    height: 80,
+  });
+  assert.deepEqual(calculateDashPlacement(workArea, 80, 400, 10, 'left'), {
+    x: 110,
+    y: 200,
+    width: 80,
+    height: 400,
+  });
+  assert.deepEqual(calculateDashPlacement(workArea, 80, 400, 10, 'right'), {
+    x: 1010,
+    y: 200,
+    width: 80,
+    height: 400,
+  });
+});
+
+test('dash icon size treats configured size as a maximum', () => {
+  assert.equal(selectDashIconSize(64, 47, 1), 32);
+  assert.equal(selectDashIconSize(48, 200, 1), 48);
+  assert.equal(selectDashIconSize(64, 96, 2), 48);
+});
+
+test('dash reorder position follows the active orientation', () => {
+  assert.equal(
+    calculateDashReorderPosition({
+      position: 'bottom',
+      pointerX: 75,
+      pointerY: 5,
+      childCount: 4,
+      mainAxisSize: 100,
+    }),
+    3,
+  );
+  assert.equal(
+    calculateDashReorderPosition({
+      position: 'left',
+      pointerX: 5,
+      pointerY: 75,
+      childCount: 4,
+      mainAxisSize: 100,
+    }),
+    3,
+  );
+});
+
+test('dash reorder position excludes an animated placeholder from the usable axis', () => {
+  assert.equal(
+    calculateDashReorderPosition({
+      position: 'left',
+      pointerX: 5,
+      pointerY: 75,
+      childCount: 4,
+      mainAxisSize: 125,
+      excludedMainAxisSize: 25,
+    }),
+    3,
+  );
+});
+
+test('dash reorder self-check ignores applications that are not favorites yet', () => {
+  assert.equal(isSelfReorderPosition(-1, 0), false);
+  assert.equal(isSelfReorderPosition(2, 2), true);
+  assert.equal(isSelfReorderPosition(2, 3), true);
+  assert.equal(isSelfReorderPosition(2, 4), false);
+});

--- a/tests/unit/dock/dockConfiguration.test.ts
+++ b/tests/unit/dock/dockConfiguration.test.ts
@@ -8,6 +8,7 @@ import {
 } from '~/dock/dockConfiguration.ts';
 
 const base: DockConfiguration = {
+  position: 'bottom',
   alwaysShow: false,
   intellihide: false,
   showOnAllMonitors: false,
@@ -16,7 +17,6 @@ const base: DockConfiguration = {
   showExternalStorage: true,
   motionEnabled: true,
   motionProfile: 'subtle',
-  excludePip: false,
 };
 
 test('dock configuration keeps always-show and intellihide mutually exclusive', () => {
@@ -33,10 +33,15 @@ test('dock configuration controller publishes typed snapshots and transition sco
   assert.notEqual(transition.snapshot, controller.snapshot);
 });
 
-test('dock configuration distinguishes rebuild, motion and PiP updates', () => {
+test('dock configuration distinguishes rebuild, icon-size and motion updates', () => {
+  assert.equal(classifyDockConfigurationChange(base, { ...base, position: 'left' }), 'rebuild');
   assert.equal(classifyDockConfigurationChange(base, { ...base, showTrash: false }), 'rebuild');
   assert.equal(classifyDockConfigurationChange(base, { ...base, maxIconSize: 32 }), 'icon-size');
   assert.equal(classifyDockConfigurationChange(base, { ...base, motionEnabled: false }), 'motion');
-  assert.equal(classifyDockConfigurationChange(base, { ...base, excludePip: true }), 'pip');
   assert.equal(classifyDockConfigurationChange(base, { ...base }), 'none');
+});
+
+test('dock configuration normalizes unsupported positions to bottom', () => {
+  const invalid = { ...base, position: 'top' as DockConfiguration['position'] };
+  assert.equal(normalizeDockConfiguration(invalid).position, 'bottom');
 });

--- a/tests/unit/dock/externalStorageModel.test.ts
+++ b/tests/unit/dock/externalStorageModel.test.ts
@@ -18,6 +18,7 @@ function candidate(overrides: Partial<ExternalStorageCandidate>): ExternalStorag
     isShadowed: false,
     canMount: false,
     hasMount: true,
+    isRemovable: true,
     ...overrides,
   };
 }
@@ -52,6 +53,30 @@ test('selectExternalStorageEntries excludes network volumes and non-native orpha
 
 test('selectExternalStorageEntries excludes unmountable volumes without mounts', () => {
   assert.deepEqual(selectExternalStorageEntries([candidate({ hasMount: false })]), []);
+});
+
+test('selectExternalStorageEntries excludes non-removable system volumes', () => {
+  const entries = selectExternalStorageEntries([
+    candidate({
+      id: 'volume:fedora_fedora',
+      name: 'fedora_fedora',
+      volumeClass: 'device',
+      hasMount: false,
+      canMount: true,
+      isRemovable: false,
+    }),
+  ]);
+
+  assert.deepEqual(entries, []);
+});
+
+test('selectExternalStorageEntries excludes non-removable orphan mounts', () => {
+  assert.deepEqual(
+    selectExternalStorageEntries([
+      candidate({ id: 'mount:root', kind: 'mount', isRemovable: false }),
+    ]),
+    [],
+  );
 });
 
 test('selectExternalStorageEntries deduplicates stable ids and sorts by sort key', () => {

--- a/tests/unit/dock/intellihideState.test.ts
+++ b/tests/unit/dock/intellihideState.test.ts
@@ -77,52 +77,7 @@ test('getBlockingOverlapState lets a topmost small window reveal when focus is o
   assert.deepEqual(state.rectangles, [topmostSmallWindow]);
 });
 
-test('getBlockingOverlapState does not let a focused PiP reveal over fullscreen', () => {
-  const dock = rect(700, 1030, 600, 50);
-  const backgroundFullscreenWindow = rect(0, 0, 1920, 1080);
-  const focusedPipWindow = rect(100, 100, 500, 300);
-
-  const state = getBlockingOverlapState(
-    [
-      { rectangle: backgroundFullscreenWindow, fullscreen: true },
-      {
-        rectangle: focusedPipWindow,
-        focused: true,
-        topmost: true,
-        excludedFromSmartReveal: true,
-      },
-    ],
-    dock,
-    true,
-  );
-
-  assert.equal(state.blocked, true);
-  assert.deepEqual(state.rectangles, [backgroundFullscreenWindow]);
-});
-
-test('getBlockingOverlapState keeps the dock hidden while PiP is focused without fullscreen', () => {
-  const dock = rect(700, 1030, 600, 50);
-  const backgroundWindow = rect(0, 0, 600, 500);
-  const focusedPipWindow = rect(100, 100, 500, 300);
-
-  const state = getBlockingOverlapState(
-    [
-      { rectangle: backgroundWindow },
-      {
-        rectangle: focusedPipWindow,
-        focused: true,
-        topmost: true,
-        excludedFromSmartReveal: true,
-      },
-    ],
-    dock,
-    false,
-  );
-
-  assert.equal(state.blocked, true);
-});
-
-test('getBlockingOverlapState keeps ordinary small-window reveal when PiP exclusion is off', () => {
+test('getBlockingOverlapState reveals for a focused small window over a fullscreen one', () => {
   const dock = rect(700, 1030, 600, 50);
   const backgroundFullscreenWindow = rect(0, 0, 1920, 1080);
   const focusedSmallWindow = rect(100, 100, 500, 300);
@@ -138,47 +93,6 @@ test('getBlockingOverlapState keeps ordinary small-window reveal when PiP exclus
 
   assert.equal(state.blocked, false);
   assert.deepEqual(state.rectangles, [focusedSmallWindow]);
-});
-
-test('getBlockingOverlapState still lets an excluded PiP block by overlapping the dock', () => {
-  const dock = rect(700, 1030, 600, 50);
-  const overlappingPipWindow = rect(800, 1000, 500, 100);
-
-  const state = getBlockingOverlapState(
-    [
-      {
-        rectangle: overlappingPipWindow,
-        focused: true,
-        topmost: true,
-        excludedFromSmartReveal: true,
-      },
-    ],
-    dock,
-    false,
-  );
-
-  assert.equal(state.blocked, true);
-  assert.deepEqual(state.rectangles, [overlappingPipWindow]);
-});
-
-test('getBlockingOverlapState does not reveal for an excluded PiP when focus is on another monitor', () => {
-  const dock = rect(700, 1030, 600, 50);
-  const topmostPipWindow = rect(100, 100, 500, 300);
-
-  const state = getBlockingOverlapState(
-    [
-      {
-        rectangle: topmostPipWindow,
-        topmost: true,
-        excludedFromSmartReveal: true,
-      },
-    ],
-    dock,
-    false,
-  );
-
-  assert.equal(state.blocked, true);
-  assert.deepEqual(state.rectangles, [topmostPipWindow]);
 });
 
 test('getBlockingOverlapState blocks when the focused window overlaps the dock', () => {

--- a/tests/unit/dock/monitorTopology.test.ts
+++ b/tests/unit/dock/monitorTopology.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { getDockMonitorIndexes, hasDefinedBottom } from '~/dock/monitorTopology.ts';
+import { getDockMonitorIndexes, hasDefinedBottom, hasDefinedEdge } from '~/dock/monitorTopology.ts';
 
 const mon = (x: number, y: number, width: number, height: number) => ({
   x,
@@ -10,61 +10,84 @@ const mon = (x: number, y: number, width: number, height: number) => ({
   height,
 });
 
-test('hasDefinedBottom — single monitor returns true', () => {
+test('hasDefinedBottom: single monitor returns true', () => {
   assert.strictEqual(hasDefinedBottom([mon(0, 0, 1920, 1080)], 0), true);
 });
 
-test('hasDefinedBottom — monitor with another directly below returns false', () => {
+test('hasDefinedBottom: monitor with another directly below returns false', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(0, 1080, 1920, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, 0), false);
   assert.strictEqual(hasDefinedBottom(monitors, 1), true);
 });
 
-test('hasDefinedBottom — side-by-side monitors both return true', () => {
+test('hasDefinedBottom: side-by-side monitors both return true', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, 0), true);
   assert.strictEqual(hasDefinedBottom(monitors, 1), true);
 });
 
-test('hasDefinedBottom — monitor with partial-overlap below returns false', () => {
+test('hasDefinedBottom: monitor with partial-overlap below returns false', () => {
   // Second monitor starts at the bottom edge of the first and overlaps in X
   const monitors = [mon(0, 0, 1920, 1080), mon(960, 1080, 960, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, 0), false);
 });
 
-test('hasDefinedBottom — monitor with non-overlapping X below returns true', () => {
+test('hasDefinedBottom: monitor with non-overlapping X below returns true', () => {
   // Second monitor is below but entirely to the right with no X overlap
   const monitors = [mon(0, 0, 1920, 1080), mon(1920, 1080, 1920, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, 0), true);
 });
 
-test('hasDefinedBottom — out-of-bounds index returns false', () => {
+test('hasDefinedBottom: out-of-bounds index returns false', () => {
   const monitors = [mon(0, 0, 1920, 1080)];
   assert.strictEqual(hasDefinedBottom(monitors, -1), false);
   assert.strictEqual(hasDefinedBottom(monitors, 5), false);
 });
 
-test('getDockMonitorIndexes — primary-only mode selects only the primary monitor', () => {
+test('getDockMonitorIndexes: primary-only mode selects only the primary monitor', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
   assert.deepEqual(getDockMonitorIndexes(monitors, 1, false), [1]);
 });
 
-test('getDockMonitorIndexes — primary-only mode follows a changed primary monitor', () => {
+test('getDockMonitorIndexes: primary-only mode follows a changed primary monitor', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
   assert.deepEqual(getDockMonitorIndexes(monitors, 0, false), [0]);
   assert.deepEqual(getDockMonitorIndexes(monitors, 1, false), [1]);
 });
 
-test('getDockMonitorIndexes — primary-only mode keeps a primary with a monitor below it', () => {
+test('getDockMonitorIndexes: primary-only mode keeps a primary with a monitor below it', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(0, 1080, 1920, 1080)];
   assert.deepEqual(getDockMonitorIndexes(monitors, 0, false), [0]);
 });
 
-test('getDockMonitorIndexes — all-monitors mode excludes internal bottom edges', () => {
+test('getDockMonitorIndexes: all-monitors mode excludes internal bottom edges', () => {
   const monitors = [mon(0, 0, 1920, 1080), mon(0, 1080, 1920, 1080), mon(1920, 0, 1920, 1080)];
   assert.deepEqual(getDockMonitorIndexes(monitors, 0, true), [1, 2]);
 });
 
-test('getDockMonitorIndexes — invalid primary produces no dock in primary-only mode', () => {
+test('getDockMonitorIndexes: invalid primary produces no dock in primary-only mode', () => {
   assert.deepEqual(getDockMonitorIndexes([mon(0, 0, 1920, 1080)], -1, false), []);
+});
+
+test('hasDefinedEdge: side-by-side monitors expose only their outside side edges', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  assert.equal(hasDefinedEdge(monitors, 0, 'left'), true);
+  assert.equal(hasDefinedEdge(monitors, 0, 'right'), false);
+  assert.equal(hasDefinedEdge(monitors, 1, 'left'), false);
+  assert.equal(hasDefinedEdge(monitors, 1, 'right'), true);
+});
+
+test('hasDefinedEdge: a monitor beyond a gap still occupies that edge', () => {
+  const horizontalGap = [mon(0, 0, 1920, 1080), mon(2020, 0, 1920, 1080)];
+  assert.equal(hasDefinedEdge(horizontalGap, 0, 'right'), false);
+  assert.equal(hasDefinedEdge(horizontalGap, 1, 'left'), false);
+
+  const verticalGap = [mon(0, 0, 1920, 1080), mon(0, 1180, 1920, 1080)];
+  assert.equal(hasDefinedEdge(verticalGap, 0, 'bottom'), false);
+});
+
+test('getDockMonitorIndexes: all-monitors mode excludes inaccessible side edges', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  assert.deepEqual(getDockMonitorIndexes(monitors, 0, true, 'left'), [0]);
+  assert.deepEqual(getDockMonitorIndexes(monitors, 0, true, 'right'), [1]);
 });

--- a/tests/unit/dock/motion/catalog.test.ts
+++ b/tests/unit/dock/motion/catalog.test.ts
@@ -8,11 +8,11 @@ import {
   isBuiltInProfile,
 } from '~/dock/motion/catalog.ts';
 
-test('dock motion catalog — Subtle is the default profile', () => {
+test('dock motion catalog: Subtle is the default profile', () => {
   assert.equal(DEFAULT_PROFILE, Profile.SUBTLE);
 });
 
-test('dock motion catalog — recognizes only the three built-in profiles', () => {
+test('dock motion catalog: recognizes only the three built-in profiles', () => {
   assert.equal(isBuiltInProfile('subtle'), true);
   assert.equal(isBuiltInProfile('balanced'), true);
   assert.equal(isBuiltInProfile('expressive'), true);
@@ -20,11 +20,11 @@ test('dock motion catalog — recognizes only the three built-in profiles', () =
   assert.equal(isBuiltInProfile('nonsense'), false);
 });
 
-test('dock motion catalog — falls back to the default profile for unknown ids', () => {
+test('dock motion catalog: falls back to the default profile for unknown ids', () => {
   assert.deepEqual(getBuiltInRecipe('nonsense'), getBuiltInRecipe(DEFAULT_PROFILE));
 });
 
-test('dock motion catalog — Subtle gives only the selected icon a gentle hover', () => {
+test('dock motion catalog: Subtle gives only the selected icon a gentle hover', () => {
   const recipe = getBuiltInRecipe(Profile.SUBTLE);
   assert.equal(recipe.hover.enabled, true);
   assert.equal(recipe.hover.scale, 1.05);
@@ -34,7 +34,7 @@ test('dock motion catalog — Subtle gives only the selected icon a gentle hover
   assert.equal(recipe.press.mode, 'all-primary-clicks');
 });
 
-test('dock motion catalog — Balanced only grows the selected icon', () => {
+test('dock motion catalog: Balanced only grows the selected icon', () => {
   const recipe = getBuiltInRecipe(Profile.BALANCED);
   assert.equal(recipe.hover.enabled, true);
   assert.equal(recipe.hover.scale, 1.1);
@@ -43,7 +43,7 @@ test('dock motion catalog — Balanced only grows the selected icon', () => {
   assert.equal(recipe.press.mode, 'launches-only');
 });
 
-test('dock motion catalog — Expressive is stronger without overlapping neighboring icons', () => {
+test('dock motion catalog: Expressive is stronger without overlapping neighboring icons', () => {
   const recipe = getBuiltInRecipe(Profile.EXPRESSIVE);
   assert.ok(recipe.hover.scale > getBuiltInRecipe(Profile.BALANCED).hover.scale);
   assert.equal(recipe.hover.scale, 1.15);
@@ -52,7 +52,7 @@ test('dock motion catalog — Expressive is stronger without overlapping neighbo
   assert.equal(recipe.hover.easing, 'ease-out-cubic');
 });
 
-test('dock motion catalog — recipes are independent copies, not shared references', () => {
+test('dock motion catalog: recipes are independent copies, not shared references', () => {
   const first = getBuiltInRecipe(Profile.BALANCED);
   const second = getBuiltInRecipe(Profile.BALANCED);
   first.hover.scale = 999;

--- a/tests/unit/dock/motion/pressInteraction.test.ts
+++ b/tests/unit/dock/motion/pressInteraction.test.ts
@@ -4,28 +4,28 @@ import { test } from 'node:test';
 import { getBuiltInRecipe, Profile } from '~/dock/motion/catalog.ts';
 import { PressInteraction } from '~/dock/motion/pressInteraction.ts';
 
-test('press interaction — ALL_PRIMARY_CLICKS presses immediately regardless of launch state', () => {
+test('press interaction: ALL_PRIMARY_CLICKS presses immediately regardless of launch state', () => {
   const { press } = getBuiltInRecipe(Profile.EXPRESSIVE); // all-primary-clicks
   const interaction = new PressInteraction();
   assert.equal(interaction.beginPrimary(press, false), true);
   assert.equal(interaction.pressed, true);
 });
 
-test('press interaction — LAUNCHES_ONLY stays idle for clicks on a running app', () => {
+test('press interaction: LAUNCHES_ONLY stays idle for clicks on a running app', () => {
   const { press } = getBuiltInRecipe(Profile.BALANCED); // launches-only
   const interaction = new PressInteraction();
   assert.equal(interaction.beginPrimary(press, false), false);
   assert.equal(interaction.pressed, false);
 });
 
-test('press interaction — LAUNCHES_ONLY presses for a click that starts a stopped app', () => {
+test('press interaction: LAUNCHES_ONLY presses for a click that starts a stopped app', () => {
   const { press } = getBuiltInRecipe(Profile.BALANCED);
   const interaction = new PressInteraction();
   assert.equal(interaction.beginPrimary(press, true), true);
   assert.equal(interaction.pressed, true);
 });
 
-test('press interaction — finishClick releases an active press exactly once', () => {
+test('press interaction: finishClick releases an active press exactly once', () => {
   const { press } = getBuiltInRecipe(Profile.EXPRESSIVE);
   const interaction = new PressInteraction();
   interaction.beginPrimary(press, false);
@@ -34,7 +34,7 @@ test('press interaction — finishClick releases an active press exactly once', 
   assert.equal(interaction.finishClick(), false); // already released, no change
 });
 
-test('press interaction — syncButtonPressed releases an early drag-out before click fires', () => {
+test('press interaction: syncButtonPressed releases an early drag-out before click fires', () => {
   const { press } = getBuiltInRecipe(Profile.EXPRESSIVE);
   const interaction = new PressInteraction();
   interaction.beginPrimary(press, false);
@@ -43,7 +43,7 @@ test('press interaction — syncButtonPressed releases an early drag-out before 
   assert.equal(interaction.pressed, false);
 });
 
-test('press interaction — reset clears an in-progress press (e.g. pointer leaves)', () => {
+test('press interaction: reset clears an in-progress press (e.g. pointer leaves)', () => {
   const { press } = getBuiltInRecipe(Profile.EXPRESSIVE);
   const interaction = new PressInteraction();
   interaction.beginPrimary(press, false);
@@ -51,7 +51,7 @@ test('press interaction — reset clears an in-progress press (e.g. pointer leav
   assert.equal(interaction.pressed, false);
 });
 
-test('press interaction — disabled press config never presses', () => {
+test('press interaction: disabled press config never presses', () => {
   const { press } = getBuiltInRecipe(Profile.EXPRESSIVE);
   const interaction = new PressInteraction();
   assert.equal(interaction.beginPrimary({ ...press, enabled: false }, true), false);

--- a/tests/unit/dock/motion/transforms.test.ts
+++ b/tests/unit/dock/motion/transforms.test.ts
@@ -12,7 +12,7 @@ import {
   textureRenderSize,
 } from '~/dock/motion/transforms.ts';
 
-test('transforms — squash press shrinks the vertical axis toward the dock', () => {
+test('transforms: squash press shrinks the vertical axis toward the dock', () => {
   const identity = resolvePressTransform(PressEffect.SQUASH, 0);
   assert.equal(identity.scaleY, 1);
   const pressed = resolvePressTransform(PressEffect.SQUASH, 1);
@@ -20,20 +20,35 @@ test('transforms — squash press shrinks the vertical axis toward the dock', ()
   assert.equal(pressed.scaleX, 1);
 });
 
-test('transforms — dim press only changes opacity, not geometry', () => {
+test('transforms: side dock uses an edge pivot, inward lift and horizontal squash', () => {
+  const recipe = getBuiltInRecipe(Profile.BALANCED);
+  recipe.hover.lift = 8;
+  const left = resolveIconTransform({ recipe, hovered: true, position: 'left' });
+  const right = resolveIconTransform({ recipe, hovered: true, position: 'right' });
+  const pressed = resolvePressTransform(PressEffect.SQUASH, 1, 'left');
+
+  assert.deepEqual(left.pivot, [0, 0.5]);
+  assert.ok(left.translationX > 0);
+  assert.deepEqual(right.pivot, [1, 0.5]);
+  assert.ok(right.translationX < 0);
+  assert.ok(pressed.scaleX < 1);
+  assert.equal(pressed.scaleY, 1);
+});
+
+test('transforms: dim press only changes opacity, not geometry', () => {
   const pressed = resolvePressTransform(PressEffect.DIM, 1);
   assert.equal(pressed.scaleX, 1);
   assert.equal(pressed.scaleY, 1);
   assert.ok(pressed.dim > 0);
 });
 
-test('transforms — dimOpacity scales down from the original, clamped to [0, 1]', () => {
+test('transforms: dimOpacity scales down from the original, clamped to [0, 1]', () => {
   assert.equal(dimOpacity(255, 0), 255);
   assert.equal(dimOpacity(255, 1), 0);
   assert.equal(dimOpacity(200, 0.5), 100);
 });
 
-test('transforms — neighborScaleAt fades linearly to identity past the radius', () => {
+test('transforms: neighborScaleAt fades linearly to identity past the radius', () => {
   const hover = {
     ...getBuiltInRecipe(Profile.EXPRESSIVE).hover,
     neighborScale: 1.08,
@@ -44,13 +59,13 @@ test('transforms — neighborScaleAt fades linearly to identity past the radius'
   assert.equal(neighborScaleAt(hover, 3), 1); // beyond the radius
 });
 
-test('transforms — fitHoverToBudget leaves room untouched when it already fits', () => {
+test('transforms: fitHoverToBudget leaves room untouched when it already fits', () => {
   const fitted = fitHoverToBudget(1.1, 5, 48, 1000);
   assert.equal(fitted.hoverScale, 1.1);
   assert.equal(fitted.lift, 5);
 });
 
-test('transforms — fitHoverToBudget shrinks scale and lift proportionally when clipped', () => {
+test('transforms: fitHoverToBudget shrinks scale and lift proportionally when clipped', () => {
   const fitted = fitHoverToBudget(1.5, 10, 48, 12);
   const reachBefore = 48 * 0.5 + 10;
   const reachAfter = 48 * (fitted.hoverScale - 1) + fitted.lift;
@@ -58,7 +73,7 @@ test('transforms — fitHoverToBudget shrinks scale and lift proportionally when
   assert.ok(reachAfter < reachBefore);
 });
 
-test('transforms — Subtle has a visible but gentler hover than Balanced', () => {
+test('transforms: Subtle has a visible but gentler hover than Balanced', () => {
   const recipe = getBuiltInRecipe(Profile.SUBTLE);
   const transform = resolveIconTransform({ recipe, hovered: true });
   assert.equal(hoverNeedsBudget({ recipe, hovered: true }), true);
@@ -66,7 +81,7 @@ test('transforms — Subtle has a visible but gentler hover than Balanced', () =
   assert.ok(transform.scaleX < getBuiltInRecipe(Profile.BALANCED).hover.scale);
 });
 
-test('transforms — resolveIconTransform is identity when animations are globally off', () => {
+test('transforms: resolveIconTransform is identity when animations are globally off', () => {
   const recipe = getBuiltInRecipe(Profile.EXPRESSIVE);
   const transform = resolveIconTransform({ recipe, hovered: true, animationsEnabled: false });
   assert.equal(transform.scaleX, 1);
@@ -74,21 +89,21 @@ test('transforms — resolveIconTransform is identity when animations are global
   assert.equal(transform.translationY, 0);
 });
 
-test('transforms — resolveIconTransform scales and lifts on hover for Balanced', () => {
+test('transforms: resolveIconTransform scales and lifts on hover for Balanced', () => {
   const recipe = getBuiltInRecipe(Profile.BALANCED);
   const transform = resolveIconTransform({ recipe, hovered: true });
   assert.equal(transform.scaleX, 1.1);
   assert.equal(transform.scaleY, 1.1);
 });
 
-test('transforms — Balanced leaves neighboring icons at their normal size', () => {
+test('transforms: Balanced leaves neighboring icons at their normal size', () => {
   const recipe = getBuiltInRecipe(Profile.BALANCED);
   const transform = resolveIconTransform({ recipe, neighborDistance: 1 });
   assert.equal(transform.scaleX, 1);
   assert.equal(transform.scaleY, 1);
 });
 
-test('transforms — Expressive leaves neighboring icons at their normal size', () => {
+test('transforms: Expressive leaves neighboring icons at their normal size', () => {
   const recipe = getBuiltInRecipe(Profile.EXPRESSIVE);
   const transform = resolveIconTransform({ recipe, neighborDistance: 1 });
   assert.equal(transform.scaleX, 1);
@@ -96,13 +111,13 @@ test('transforms — Expressive leaves neighboring icons at their normal size', 
   assert.equal(transform.translationY, 0);
 });
 
-test('transforms — textureRenderSize uses 2x pixels for smooth hover magnification', () => {
+test('transforms: textureRenderSize uses 2x pixels for smooth hover magnification', () => {
   const recipe = getBuiltInRecipe(Profile.BALANCED);
   assert.equal(textureRenderSize(48, recipe), 96);
   assert.ok(textureRenderSize(48, recipe) >= 48 * recipe.hover.scale);
 });
 
-test('transforms — textureRenderSize stays at the normal size when hover is disabled', () => {
+test('transforms: textureRenderSize stays at the normal size when hover is disabled', () => {
   const recipe = getBuiltInRecipe(Profile.SUBTLE);
   recipe.hover.enabled = false;
   assert.equal(textureRenderSize(48, recipe), 48);

--- a/tests/unit/module.test.ts
+++ b/tests/unit/module.test.ts
@@ -14,19 +14,19 @@ function manifest(runtime?: ModuleManifest['runtime']): ModuleManifest {
   };
 }
 
-test('runtime — modules default to desktop role', () => {
+test('runtime: modules default to desktop role', () => {
   const item = manifest();
   assert.equal(moduleSupportsRuntime(item, new Set(['desktop']), new Set()), true);
   assert.equal(moduleSupportsRuntime(item, new Set(['mobile']), new Set()), false);
 });
 
-test('runtime — a manifest supports both roles explicitly', () => {
+test('runtime: a manifest supports both roles explicitly', () => {
   const item = manifest({ roles: ['desktop', 'mobile'] });
   assert.equal(moduleSupportsRuntime(item, new Set(['desktop']), new Set()), true);
   assert.equal(moduleSupportsRuntime(item, new Set(['mobile']), new Set()), true);
 });
 
-test('runtime — required capabilities must be present', () => {
+test('runtime: required capabilities must be present', () => {
   const item = manifest({ roles: ['desktop'], requires: ['backlight'] });
   assert.equal(moduleSupportsRuntime(item, new Set(['desktop']), new Set()), false);
   assert.equal(moduleSupportsRuntime(item, new Set(['desktop']), new Set(['backlight'])), true);

--- a/tests/unit/moduleManager.test.ts
+++ b/tests/unit/moduleManager.test.ts
@@ -88,7 +88,7 @@ function setup(definition: ModuleDefinition): {
   return { manager, settings, device, errors };
 }
 
-test('ModuleManager — follows settings and tears modules down', () => {
+test('ModuleManager: follows settings and tears modules down', () => {
   let enables = 0;
   let disables = 0;
   const item: Module = { enable: () => enables++, disable: () => disables++ } as Module;
@@ -102,7 +102,7 @@ test('ModuleManager — follows settings and tears modules down', () => {
   assert.equal(state.settings.listeners.size, 0);
 });
 
-test('ModuleManager — discards and cleans a module whose enable fails', () => {
+test('ModuleManager: discards and cleans a module whose enable fails', () => {
   let disables = 0;
   const item: Module = {
     enable: () => {
@@ -119,7 +119,7 @@ test('ModuleManager — discards and cleans a module whose enable fails', () => 
   state.manager.stop();
 });
 
-test('ModuleManager — surfaces cleanup failures after a module fails to enable', () => {
+test('ModuleManager: surfaces cleanup failures after a module fails to enable', () => {
   const item: Module = {
     enable: () => {
       throw new Error('enable failed');
@@ -136,7 +136,7 @@ test('ModuleManager — surfaces cleanup failures after a module fails to enable
   assert.deepEqual(state.errors, ['Failed to enable module sample: Error: enable failed']);
 });
 
-test('ModuleManager — surfaces module disable failures', () => {
+test('ModuleManager: surfaces module disable failures', () => {
   const item: Module = {
     enable: () => undefined,
     disable: () => {
@@ -151,7 +151,7 @@ test('ModuleManager — surfaces module disable failures', () => {
   assert.equal(state.manager.getModule('sample'), null);
 });
 
-test('ModuleManager — reconciles capability changes', () => {
+test('ModuleManager: reconciles capability changes', () => {
   let enables = 0;
   let disables = 0;
   const state = setup({
@@ -168,7 +168,7 @@ test('ModuleManager — reconciles capability changes', () => {
   state.manager.stop();
 });
 
-test('ModuleManager — stop is idempotent and disables in reverse order', () => {
+test('ModuleManager: stop is idempotent and disables in reverse order', () => {
   const order: string[] = [];
   const definitions: ModuleDefinition[] = ['first', 'second'].map((key) => ({
     manifest: { ...manifest(), key, settingsKey: `module-${key}` },

--- a/tests/unit/panel/auroraMenuState.test.ts
+++ b/tests/unit/panel/auroraMenuState.test.ts
@@ -9,7 +9,7 @@ import {
   truncateMiddle,
 } from '~/panel/auroraMenuState.ts';
 
-test('Aurora Menu state — parses label and command around the first separator', () => {
+test('Aurora Menu state: parses label and command around the first separator', () => {
   assert.deepEqual(parseCustomCommand('Terminal | foot --working-directory=/tmp|logs'), {
     label: 'Terminal',
     command: 'foot --working-directory=/tmp|logs',
@@ -19,7 +19,7 @@ test('Aurora Menu state — parses label and command around the first separator'
   assert.equal(parseCustomCommand('missing command | '), null);
 });
 
-test('Aurora Menu state — parses, deduplicates and sorts recent XBEL bookmarks', () => {
+test('Aurora Menu state: parses, deduplicates and sorts recent XBEL bookmarks', () => {
   const xml = `<xbel>
     <bookmark href="file:///tmp/older.txt" modified="2026-01-01T10:00:00Z"><title>Older</title></bookmark>
     <bookmark href="https://example.com" modified="2026-01-02T10:00:00Z"><title>Example &amp; Docs</title></bookmark>
@@ -31,18 +31,18 @@ test('Aurora Menu state — parses, deduplicates and sorts recent XBEL bookmarks
   );
 });
 
-test('Aurora Menu state — serializes custom commands in the settings format', () => {
+test('Aurora Menu state: serializes custom commands in the settings format', () => {
   assert.equal(
     serializeCustomCommand({ label: '  Terminal  ', command: '  ptyxis --new-window  ' }),
     'Terminal | ptyxis --new-window',
   );
 });
 
-test('Aurora Menu state — decodes XML entities in recent item labels', () => {
+test('Aurora Menu state: decodes XML entities in recent item labels', () => {
   assert.equal(decodeXml('A &amp; B &lt;C&gt; &quot;D&quot; &apos;E&apos;'), 'A & B <C> "D" \'E\'');
 });
 
-test('Aurora Menu state — truncates the middle while preserving both edges', () => {
+test('Aurora Menu state: truncates the middle while preserving both edges', () => {
   assert.equal(truncateMiddle('abcdefghij', 7), 'abc…hij');
   assert.equal(truncateMiddle('short', 7), 'short');
 });

--- a/tests/unit/panel/clock/meetingClock/meetingClockLogic.test.ts
+++ b/tests/unit/panel/clock/meetingClock/meetingClockLogic.test.ts
@@ -29,7 +29,7 @@ function event(overrides: Partial<MeetingEvent> = {}): MeetingEvent {
   };
 }
 
-test('meetingClock — normalizes CalendarServer events and detects meeting URL', () => {
+test('meetingClock: normalizes CalendarServer events and detects meeting URL', () => {
   const normalized = normalizeCalendarServerEvent([
     'calendar-1 event-1',
     'Daily Sync',
@@ -49,7 +49,7 @@ test('meetingClock — normalizes CalendarServer events and detects meeting URL'
   assert.strictEqual(normalized.meetingUrl, 'https://meet.google.com/abc-defg-hij');
 });
 
-test('meetingClock — calculates the next alert across lead time and snooze state', () => {
+test('meetingClock: calculates the next alert across lead time and snooze state', () => {
   const now = 1_000;
   const first = event({
     id: 'first',
@@ -73,7 +73,7 @@ test('meetingClock — calculates the next alert across lead time and snooze sta
   assert.equal(next, 1_450);
 });
 
-test('meetingClock — prefers video meeting URLs over generic links', () => {
+test('meetingClock: prefers video meeting URLs over generic links', () => {
   const url = extractMeetingUrl({
     description: 'Notes: https://example.com Agenda: https://zoom.us/j/12345',
   });
@@ -81,7 +81,7 @@ test('meetingClock — prefers video meeting URLs over generic links', () => {
   assert.strictEqual(url, 'https://zoom.us/j/12345');
 });
 
-test('meetingClock — prefers a meeting URL from the description over an earlier generic URL', () => {
+test('meetingClock: prefers a meeting URL from the description over an earlier generic URL', () => {
   const url = extractMeetingUrl({
     url: 'https://calendar.example.com/event/12345',
     description: 'Join: https://teams.microsoft.com/meet/247507021276381?p=ExamplePasscode',
@@ -90,7 +90,7 @@ test('meetingClock — prefers a meeting URL from the description over an earlie
   assert.strictEqual(url, 'https://teams.microsoft.com/meet/247507021276381?p=ExamplePasscode');
 });
 
-test('meetingClock — restores wrapped Microsoft Teams meeting URLs', () => {
+test('meetingClock: restores wrapped Microsoft Teams meeting URLs', () => {
   const url = extractMeetingUrl({
     description: [
       'Microsoft Teams meeting',
@@ -103,7 +103,7 @@ test('meetingClock — restores wrapped Microsoft Teams meeting URLs', () => {
   assert.strictEqual(url, 'https://teams.microsoft.com/meet/247507021276381?p=ExamplePasscode');
 });
 
-test('meetingClock — restores wrapped angle-bracket meeting URLs', () => {
+test('meetingClock: restores wrapped angle-bracket meeting URLs', () => {
   const url = extractMeetingUrl({
     description: [
       'System reference <https://teams.microsoft.com/l/meetup-join/',
@@ -117,7 +117,7 @@ test('meetingClock — restores wrapped angle-bracket meeting URLs', () => {
   );
 });
 
-test('meetingClock — restores wrapped Zoom meeting IDs and query parameters', () => {
+test('meetingClock: restores wrapped Zoom meeting IDs and query parameters', () => {
   const url = extractMeetingUrl({
     description: [
       'Join: https://us06web.zoom.us/j/12345678',
@@ -141,7 +141,7 @@ test('meetingClock — restores wrapped Zoom meeting IDs and query parameters', 
   assert.strictEqual(urlWithoutQuery, 'https://zoom.us/j/1234567890');
 });
 
-test('meetingClock — restores wrapped Google Meet codes and query parameters', () => {
+test('meetingClock: restores wrapped Google Meet codes and query parameters', () => {
   const url = extractMeetingUrl({
     description: [
       'Join: https://meet.google.com/abc-',
@@ -154,7 +154,7 @@ test('meetingClock — restores wrapped Google Meet codes and query parameters',
   assert.strictEqual(url, 'https://meet.google.com/abc-defg-hij?authuser=0');
 });
 
-test('meetingClock — restores wrapped meeting URLs without provider-specific rules', () => {
+test('meetingClock: restores wrapped meeting URLs without provider-specific rules', () => {
   const url = extractMeetingUrl({
     description: [
       'Join: https://calls.example.org/rooms/session-',
@@ -170,7 +170,7 @@ test('meetingClock — restores wrapped meeting URLs without provider-specific r
   );
 });
 
-test('meetingClock — matches video providers by hostname rather than hostname-like text', () => {
+test('meetingClock: matches video providers by hostname rather than hostname-like text', () => {
   const url = extractMeetingUrl({
     description: [
       'Misleading: https://zoom.us.example.org/j/12345',
@@ -181,7 +181,7 @@ test('meetingClock — matches video providers by hostname rather than hostname-
   assert.strictEqual(url, 'https://meet.google.com/abc-defg-hij');
 });
 
-test('meetingClock — excludes all-day events from panel presentation when configured', () => {
+test('meetingClock: excludes all-day events from panel presentation when configured', () => {
   const presentation = derivePanelPresentation(
     [
       event({
@@ -198,7 +198,7 @@ test('meetingClock — excludes all-day events from panel presentation when conf
   assert.strictEqual(presentation, null);
 });
 
-test('meetingClock — panel presentation uses in-progress event before future event', () => {
+test('meetingClock: panel presentation uses in-progress event before future event', () => {
   const presentation = derivePanelPresentation(
     [
       event({ id: 'future', title: 'Later', startEpochSeconds: NOW + 3600 }),
@@ -213,7 +213,7 @@ test('meetingClock — panel presentation uses in-progress event before future e
   assert.strictEqual(presentation.label, 'Current · now');
 });
 
-test('meetingClock — panel presentation hides future events beyond configured lookahead', () => {
+test('meetingClock: panel presentation hides future events beyond configured lookahead', () => {
   const presentation = derivePanelPresentation(
     [event({ id: 'later', title: 'Much Later', startEpochSeconds: NOW + 7200 })],
     NOW,
@@ -223,7 +223,7 @@ test('meetingClock — panel presentation hides future events beyond configured 
   assert.strictEqual(presentation, null);
 });
 
-test('meetingClock — panel presentation uses compact time without parentheses', () => {
+test('meetingClock: panel presentation uses compact time without parentheses', () => {
   const presentation = derivePanelPresentation(
     [event({ id: 'soon', title: 'Soon', startEpochSeconds: NOW + 900 })],
     NOW,
@@ -234,7 +234,7 @@ test('meetingClock — panel presentation uses compact time without parentheses'
   assert.strictEqual(presentation.label, 'Soon · 15m');
 });
 
-test('meetingClock — due alerts require meeting URLs and respect ignored/alerted/snoozed state', () => {
+test('meetingClock: due alerts require meeting URLs and respect ignored/alerted/snoozed state', () => {
   const due = event({ id: 'due', meetingUrl: 'https://meet.google.com/abc-defg-hij' });
   const noLink = event({ id: 'no-link' });
   const ignored = event({ id: 'ignored', meetingUrl: 'https://zoom.us/j/1' });
@@ -257,7 +257,7 @@ test('meetingClock — due alerts require meeting URLs and respect ignored/alert
   );
 });
 
-test('meetingClock — due alerts can include events without meeting URLs when enabled', () => {
+test('meetingClock: due alerts can include events without meeting URLs when enabled', () => {
   const noLink = event({ id: 'no-link' });
 
   const dueEvents = getDueAlertEvents([noLink], NOW, {

--- a/tests/unit/panel/clock/weatherClock/weatherClockLogic.test.ts
+++ b/tests/unit/panel/clock/weatherClock/weatherClockLogic.test.ts
@@ -23,7 +23,7 @@ function snapshot(overrides: Partial<WeatherSnapshot> = {}): WeatherSnapshot {
   );
 }
 
-test('weatherClock — normalizes partial snapshots with safe defaults', () => {
+test('weatherClock: normalizes partial snapshots with safe defaults', () => {
   const normalized = normalizeWeatherSnapshot({ temperature: ' 24° ' }, NOW);
 
   assert.strictEqual(normalized.temperature, '24°');
@@ -32,7 +32,7 @@ test('weatherClock — normalizes partial snapshots with safe defaults', () => {
   assert.strictEqual(normalized.updatedAtEpochSeconds, NOW);
 });
 
-test('weatherClock — shows valid weather snapshots', () => {
+test('weatherClock: shows valid weather snapshots', () => {
   const presentation = deriveWeatherPresentation(snapshot(), NOW);
 
   assert.strictEqual(presentation.visible, true);
@@ -41,7 +41,7 @@ test('weatherClock — shows valid weather snapshots', () => {
   assert.strictEqual(presentation.label, '24°');
 });
 
-test('weatherClock — hides unavailable, offline, missing, and stale snapshots', () => {
+test('weatherClock: hides unavailable, offline, missing, and stale snapshots', () => {
   assert.strictEqual(
     deriveWeatherPresentation(snapshot({ available: false }), NOW).state,
     'unavailable',

--- a/tests/unit/project/gobjectFieldInitializers.test.ts
+++ b/tests/unit/project/gobjectFieldInitializers.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import ts from 'typescript';
+
+const sourceRoot = resolve('src');
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+function memberName(member: ts.ClassElement): string | null {
+  const name = member.name;
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) return name.text;
+  return null;
+}
+
+function hasDeclareModifier(member: ts.ClassElement): boolean {
+  return Boolean(
+    ts.canHaveModifiers(member) &&
+    ts.getModifiers(member)?.some((modifier) => modifier.kind === ts.SyntaxKind.DeclareKeyword),
+  );
+}
+
+/**
+ * Finds direct `this.<name> = ...` assignments and `this.<name>()` calls in a
+ * method body. Nested functions run later and are excluded from construction.
+ */
+function scanBody(body: ts.Node): { assigned: Set<string>; called: Set<string> } {
+  const assigned = new Set<string>();
+  const called = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionLike(node) && node !== body) return;
+
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      node.left.expression.kind === ts.SyntaxKind.ThisKeyword
+    ) {
+      assigned.add(node.left.name.text);
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.expression.kind === ts.SyntaxKind.ThisKeyword
+    ) {
+      called.add(node.expression.name.text);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(body, visit);
+  return { assigned, called };
+}
+
+/**
+ * GJS calls `_init` inside `super()`. Class field initializers run afterward
+ * and can overwrite values stored by `_init` or the methods it calls. Fields
+ * written during construction must use `declare`, which emits no initializer.
+ *
+ * The failure is silent: a separator created during `_init` was orphaned, and
+ * the next sync added a duplicate.
+ */
+test('GObject classes do not shadow `_init` assignments with field initializers', () => {
+  const violations: string[] = [];
+
+  for (const file of sourceFiles(sourceRoot)) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+
+    const visitClass = (node: ts.Node): void => {
+      if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+        const methods = new Map<string, ts.Node>();
+        const initialized = new Map<string, number>();
+
+        for (const member of node.members) {
+          const name = memberName(member);
+          if (!name) continue;
+          if (ts.isMethodDeclaration(member) && member.body) methods.set(name, member.body);
+          if (
+            ts.isPropertyDeclaration(member) &&
+            member.initializer &&
+            !hasDeclareModifier(member)
+          ) {
+            initialized.set(
+              name,
+              source.getLineAndCharacterOfPosition(member.getStart(source)).line + 1,
+            );
+          }
+        }
+
+        const entry = methods.get('_init');
+        if (entry && initialized.size > 0) {
+          // Everything the construction sequence can reach: `_init` plus the
+          // methods it calls, transitively.
+          const reachable = new Set<string>(['_init']);
+          const pending = [entry];
+          const assigned = new Set<string>();
+
+          while (pending.length > 0) {
+            const body = pending.pop();
+            if (!body) continue;
+            const scanned = scanBody(body);
+            for (const name of scanned.assigned) assigned.add(name);
+            for (const name of scanned.called) {
+              if (reachable.has(name)) continue;
+              const method = methods.get(name);
+              if (!method) continue;
+              reachable.add(name);
+              pending.push(method);
+            }
+          }
+
+          for (const [name, line] of initialized) {
+            if (!assigned.has(name)) continue;
+            violations.push(
+              `${file.slice(sourceRoot.length + 1)}:${line} \`${name}\` is written during ` +
+                '`_init` but declared with a field initializer; use `declare`',
+            );
+          }
+        }
+      }
+
+      ts.forEachChild(node, visitClass);
+    };
+
+    ts.forEachChild(source, visitClass);
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/tests/unit/project/metadata.test.ts
+++ b/tests/unit/project/metadata.test.ts
@@ -9,7 +9,7 @@ const meta = JSON.parse(readFileSync(resolve(root, 'metadata.json'), 'utf-8'));
 
 const EXPECTED_UUID = 'aurora-shell@luminusos.github.io';
 
-test('metadata.json — required fields are present', () => {
+test('metadata.json: required fields are present', () => {
   for (const field of [
     'uuid',
     'name',
@@ -27,22 +27,22 @@ test('metadata.json — required fields are present', () => {
   }
 });
 
-test('metadata.json — uuid matches expected value', () => {
+test('metadata.json: uuid matches expected value', () => {
   assert.strictEqual(meta.uuid, EXPECTED_UUID);
 });
 
-test('metadata.json — settings-schema matches uuid prefix', () => {
+test('metadata.json: settings-schema matches uuid prefix', () => {
   assert.ok(
     meta['settings-schema'].includes('aurora-shell'),
     `settings-schema "${meta['settings-schema']}" does not contain "aurora-shell"`,
   );
 });
 
-test('metadata.json — gettext-domain matches uuid', () => {
+test('metadata.json: gettext-domain matches uuid', () => {
   assert.strictEqual(meta['gettext-domain'], EXPECTED_UUID);
 });
 
-test('metadata.json — shell-version is a non-empty array of numeric strings', () => {
+test('metadata.json: shell-version is a non-empty array of numeric strings', () => {
   assert.ok(Array.isArray(meta['shell-version']), 'shell-version must be an array');
   assert.ok(meta['shell-version'].length > 0, 'shell-version must not be empty');
 
@@ -51,7 +51,7 @@ test('metadata.json — shell-version is a non-empty array of numeric strings', 
   }
 });
 
-test('metadata.json — version-name is a non-empty string', () => {
+test('metadata.json: version-name is a non-empty string', () => {
   const v = meta['version-name'];
   assert.ok(
     typeof v === 'string' && v.length > 0,

--- a/tests/unit/project/schema.test.ts
+++ b/tests/unit/project/schema.test.ts
@@ -200,48 +200,48 @@ function schemaDefault(key: string): string {
   return xml.slice(defaultStart + defaultStartTag.length, defaultEnd).trim();
 }
 
-test('schema — is structurally valid and contains every catalog module key', () => {
+test('schema: is structurally valid and contains every catalog module key', () => {
   const schemaKeys = new Set(compiledSchemaKeys());
   const moduleKeys = catalogSettingsKeys();
   for (const key of moduleKeys) assert.ok(schemaKeys.has(key), key);
   assert.equal(moduleKeys.length, new Set(moduleKeys).size);
 });
 
-test('schema — has no module switches absent from the catalog', () => {
+test('schema: has no module switches absent from the catalog', () => {
   const moduleKeys = new Set(catalogSettingsKeys().filter((key) => key.startsWith('module-')));
   const schemaModuleKeys = compiledSchemaKeys().filter((key) => key.startsWith('module-'));
   assert.deepEqual([...schemaModuleKeys].sort(), [...moduleKeys].sort());
 });
 
-test('schema ↔ catalog — every declared module and option setting is synchronized', () => {
+test('schema ↔ catalog: every declared module and option setting is synchronized', () => {
   assert.deepEqual([...compiledSchemaKeys()].sort(), [...catalogSettingsKeys()].sort());
 });
 
-test('schema — Vela VPN integration and Shell fallback are disabled by default', () => {
+test('schema: Vela VPN integration and Shell fallback are disabled by default', () => {
   assert.equal(schemaDefault('module-vela-vpn-quick-settings'), 'false');
   assert.equal(schemaDefault('vela-vpn-quick-settings-shell-fallback'), 'false');
 });
 
-test('schema — Clipboard History automatic paste is enabled by default', () => {
+test('schema: Clipboard History automatic paste is enabled by default', () => {
   assert.equal(schemaDefault('clipboard-history-auto-paste'), 'true');
 });
 
-test('schema — Capture Tools uses DuckDuckGo by default', () => {
+test('schema: Capture Tools uses DuckDuckGo by default', () => {
   assert.equal(schemaDefault('capture-tools-web-search-engine'), "'duckduckgo'");
 });
 
-test('schema — Dock defaults to the primary monitor only', () => {
+test('schema: Dock defaults to the primary monitor only', () => {
   assert.equal(schemaDefault('dock-show-on-all-monitors'), 'false');
 });
 
-test('schema — Dock preserves the GNOME default maximum icon size', () => {
+test('schema: Dock preserves the GNOME default maximum icon size', () => {
   assert.equal(schemaDefault('dock-icon-size'), '64');
 });
 
-test('schema — Dock uses always auto-hide by default', () => {
+test('schema: Dock uses always auto-hide by default', () => {
   assert.equal(schemaDefault('dock-intellihide'), 'false');
 });
 
-test('schema — Volume Mixer button is contextual by default', () => {
+test('schema: Volume Mixer button is contextual by default', () => {
   assert.equal(schemaDefault('volume-mixer-always-show'), 'false');
 });

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -141,16 +141,16 @@ const entries = catalog();
 const keys = entries.map((entry) => entry.key);
 const settingsKeys = entries.map((entry) => entry.settingsKey);
 
-test('catalog — ids and settings keys are unique', () => {
+test('catalog: ids and settings keys are unique', () => {
   assert.equal(new Set(keys).size, keys.length);
   assert.equal(new Set(settingsKeys).size, settingsKeys.length);
 });
 
-test('catalog ↔ registry — every manifest has exactly one factory', () => {
+test('catalog ↔ registry: every manifest has exactly one factory', () => {
   assert.deepEqual([...factoryKeys()].sort(), [...keys].sort());
 });
 
-test('catalog — every section is declared by moduleCatalog', () => {
+test('catalog: every section is declared by moduleCatalog', () => {
   const catalogSource = sourceFile('src/moduleCatalog.ts');
   const sections = new Set<string>();
   function visit(node: ts.Node): void {
@@ -185,7 +185,7 @@ test('prefs uses the manifest-only catalog and extension core uses the runtime r
   assert.equal(importsRegistry, true);
 });
 
-test('moduleCatalog — does not import runtime module implementations', () => {
+test('moduleCatalog: does not import runtime module implementations', () => {
   const catalogSource = sourceFile('src/moduleCatalog.ts');
   for (const statement of catalogSource.statements) {
     if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier))
@@ -199,7 +199,7 @@ test('moduleCatalog — does not import runtime module implementations', () => {
   }
 });
 
-test('catalog — desktop module baseline is preserved', () => {
+test('catalog: desktop module baseline is preserved', () => {
   assert.deepEqual(keys, [
     'no-overview',
     'pip-on-top',
@@ -226,6 +226,6 @@ test('catalog — desktop module baseline is preserved', () => {
   ]);
 });
 
-test('catalog — shared is not a device/display role', () => {
+test('catalog: shared is not a device/display role', () => {
   for (const entry of entries) assert.ok(!entry.runtimeRoles.includes('shared'), entry.key);
 });

--- a/tests/unit/shared/i18n.test.ts
+++ b/tests/unit/shared/i18n.test.ts
@@ -15,7 +15,7 @@ function typeScriptFiles(directory: string): string[] {
   });
 }
 
-test('i18n — all translated source uses the Aurora gettext domain', () => {
+test('i18n: all translated source uses the Aurora gettext domain', () => {
   for (const path of typeScriptFiles(sourceRoot)) {
     if (path.endsWith('/shared/i18n.ts')) continue;
     const source = readFileSync(path, 'utf8');
@@ -32,7 +32,7 @@ test('i18n — all translated source uses the Aurora gettext domain', () => {
   }
 });
 
-test('i18n — shared gettext domain matches metadata', () => {
+test('i18n: shared gettext domain matches metadata', () => {
   const metadata = JSON.parse(readFileSync(resolve(root, 'metadata.json'), 'utf8')) as Record<
     string,
     unknown

--- a/tests/unit/shared/ui/dashLayout.test.ts
+++ b/tests/unit/shared/ui/dashLayout.test.ts
@@ -10,7 +10,7 @@ import {
 
 const bounds = { x: 100, y: 50, width: 800, height: 600 };
 
-test('dash layout — centers and bottom-aligns inside the work area', () => {
+test('dash layout: centers and bottom-aligns inside the work area', () => {
   assert.deepEqual(calculateDashPlacement(bounds, 300, 80, 12), {
     x: 350,
     y: 558,
@@ -19,7 +19,7 @@ test('dash layout — centers and bottom-aligns inside the work area', () => {
   });
 });
 
-test('dash layout — clamps oversized or negative preferred dimensions', () => {
+test('dash layout: clamps oversized or negative preferred dimensions', () => {
   assert.deepEqual(calculateDashPlacement(bounds, 1200, -20, 0), {
     x: 100,
     y: 650,
@@ -28,26 +28,26 @@ test('dash layout — clamps oversized or negative preferred dimensions', () => 
   });
 });
 
-test('dash layout — point containment includes edges', () => {
+test('dash layout: point containment includes edges', () => {
   assert.equal(boundsContainPoint(bounds, 100, 50), true);
   assert.equal(boundsContainPoint(bounds, 900, 650), true);
   assert.equal(boundsContainPoint(bounds, 99, 50), false);
   assert.equal(boundsContainPoint(null, 100, 50), false);
 });
 
-test('dash layout — structural bounds equality handles null', () => {
+test('dash layout: structural bounds equality handles null', () => {
   assert.equal(boundsEqual(bounds, { ...bounds }), true);
   assert.equal(boundsEqual(bounds, { ...bounds, width: 799 }), false);
   assert.equal(boundsEqual(null, null), true);
   assert.equal(boundsEqual(bounds, null), false);
 });
 
-test('dash icon size — uses the configured maximum when it fits', () => {
+test('dash icon size: uses the configured maximum when it fits', () => {
   assert.equal(selectDashIconSize(40, 40, 1), 40);
   assert.equal(selectDashIconSize(64, 128, 2), 64);
 });
 
-test('dash icon size — falls back through GNOME size steps when space is limited', () => {
+test('dash icon size: falls back through GNOME size steps when space is limited', () => {
   assert.equal(selectDashIconSize(40, 31, 1), 24);
   assert.equal(selectDashIconSize(40, 70, 2), 32);
   assert.equal(selectDashIconSize(64, 8, 1), 16);


### PR DESCRIPTION
Add a dock-position setting for bottom, left, and right edges and propagate it through monitor selection, placement, hot areas, struts, visibility, drag-and-drop, motion transforms, running indicators, and styles.

Improve adaptive icon sizing and fixed-item ordering, exclude non-removable system volumes from dock shortcuts, guard intellihide against stale monitor indexes during shutdown, and use one focused/topmost/fullscreen blocking model without the PiP-specific smart-reveal exception.

Expand unit and shell coverage for edge geometry, monitor topology, icon sizing, motion, storage filtering, and GObject field initialization. Normalize test names and diagnostics, and update the schema, preferences, translations, README, and developer controls.