### PR TITLE
feat(dock): add window previews on icon hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Aurora is split into independent modules, so you can enable only what you want.
 
 ### Dock & Panel
 
-- **Dock** - replaces the stock dash with a dock on the bottom, left, or right edge of each monitor. It auto-hides by default and supports intellihide, an always-visible mode, adaptive icon sizes, edge reveal, Trash, and removable drive shortcuts.
+- **Dock** - replaces the stock dash with a dock on the bottom, left, or right edge of each monitor. It auto-hides by default and supports intellihide, an always-visible mode, adaptive icon sizes, optional live window previews and actions, edge reveal, Trash, and removable drive shortcuts.
 - **Aurora Menu** - adds an Aurora panel menu with recent items, useful shortcuts, configurable panel icon, optional Activities button hiding, and a custom command slot.
 - **Volume Mixer** - adds per-application volume sliders to Quick Settings with fast access to Sound Settings.
 - **Low Battery Percentage** - uses GNOME's native battery percentage setting while the battery is discharging below 20%, without overriding users who already enabled it.

--- a/data/po/pt_BR.po
+++ b/data/po/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aurora-shell\n"
 "Report-Msgid-Bugs-To: https://github.com/luminusOS/aurora-shell/issues\n"
-"POT-Creation-Date: 2026-08-16 17:56-0300\n"
+"POT-Creation-Date: 2026-08-19 00:55-0300\n"
 "PO-Revision-Date: 2026-07-16 09:20-0300\n"
 "Last-Translator: Aurora Shell Contributors\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -422,30 +422,41 @@ msgid "Show removable drives in the dock when they are connected"
 msgstr "Mostra unidades removíveis no dock quando estão conectadas"
 
 #: dist/dock/dock.manifest.js:67
+msgid "Window Previews"
+msgstr "Pré-visualizações de janelas"
+
+#: dist/dock/dock.manifest.js:68
+msgid ""
+"Show live previews and window actions when hovering over running applications"
+msgstr ""
+"Mostra pré-visualizações ao vivo e ações de janela ao passar o mouse sobre "
+"aplicativos em execução"
+
+#: dist/dock/dock.manifest.js:73
 msgid "Icon Hover &amp; Press Effects"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:68
+#: dist/dock/dock.manifest.js:74
 msgid "Animate dock icons on hover and click"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:73
+#: dist/dock/dock.manifest.js:79
 msgid "Effect Intensity"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:74
+#: dist/dock/dock.manifest.js:80
 msgid "How strong the hover and press effects are"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:77
+#: dist/dock/dock.manifest.js:83
 msgid "Subtle"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:78
+#: dist/dock/dock.manifest.js:84
 msgid "Balanced"
 msgstr ""
 
-#: dist/dock/dock.manifest.js:79
+#: dist/dock/dock.manifest.js:85
 msgid "Expressive"
 msgstr ""
 
@@ -1055,6 +1066,10 @@ msgstr ""
 "Oculta o conteúdo do painel durante o compartilhamento de tela; mostra "
 "apenas o indicador de compartilhamento"
 
+#: dist/shared/ui/dashWindowPreviews.js:270
+msgid "Close"
+msgstr "Fechar"
+
 #: dist/theme/autoThemeSwitcher.manifest.js:8
 msgid "Auto Theme Switcher"
 msgstr "Alternador automático de tema"
@@ -1087,6 +1102,12 @@ msgstr "Alternador de Tema"
 #: dist/theme/themeChanger.manifest.js:9
 msgid "Monitors and synchronizes GNOME color scheme"
 msgstr "Monitora e sincroniza o esquema de cores do GNOME"
+
+#~ msgid "Restore"
+#~ msgstr "Restaurar"
+
+#~ msgid "Minimize"
+#~ msgstr "Minimizar"
 
 #~ msgid "Save Changes"
 #~ msgstr "Salvar alterações"

--- a/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.aurora-shell.gschema.xml
@@ -158,6 +158,11 @@
       <summary>Show external storage</summary>
       <description>Show removable drives in the dock when they are connected</description>
     </key>
+    <key name="dock-window-previews" type="b">
+      <default>false</default>
+      <summary>Show window previews</summary>
+      <description>Show live previews and window actions when hovering over running applications in the dock</description>
+    </key>
     <key name="dock-motion-enabled" type="b">
       <default>true</default>
       <summary>Enable dock icon hover &amp; press effects</summary>

--- a/src/dock/dock.manifest.ts
+++ b/src/dock/dock.manifest.ts
@@ -61,6 +61,12 @@ export const manifest: ModuleManifest = {
       type: 'switch',
     },
     {
+      key: 'dock-window-previews',
+      title: _('Window Previews'),
+      subtitle: _('Show live previews and window actions when hovering over running applications'),
+      type: 'switch',
+    },
+    {
       key: 'dock-motion-enabled',
       title: _('Icon Hover &amp; Press Effects'),
       subtitle: _('Animate dock icons on hover and click'),

--- a/src/dock/dock.ts
+++ b/src/dock/dock.ts
@@ -43,6 +43,7 @@ export class Dock extends Module {
   private _maxIconSize = 64;
   private _showTrash = true;
   private _showExternalStorage = true;
+  private _windowPreviews = false;
   private _motionEnabled = true;
   private _motionProfile: string = DEFAULT_PROFILE;
   private _dragReveal: ContextualDragRevealCoordinator<ManagedDockBinding> | null = null;
@@ -77,6 +78,7 @@ export class Dock extends Module {
         `maxIconSize=${this._maxIconSize}`,
         `showTrash=${this._showTrash}`,
         `showExternalStorage=${this._showExternalStorage}`,
+        `windowPreviews=${this._windowPreviews}`,
         `monitors=${Main.layoutManager.monitors.length}`,
       ].join(' '),
       { prefix: LOG_PREFIX },
@@ -154,6 +156,8 @@ export class Dock extends Module {
       () => this._handleConfigurationChange('showTrash'),
       'changed::dock-show-external-storage',
       () => this._handleConfigurationChange('showExternalStorage'),
+      'changed::dock-window-previews',
+      () => this._handleConfigurationChange('windowPreviews'),
       'changed::dock-motion-enabled',
       () => this._handleConfigurationChange('motionEnabled'),
       'changed::dock-motion-profile',
@@ -188,6 +192,7 @@ export class Dock extends Module {
       maxIconSize: dockSettings.get_int('dock-icon-size'),
       showTrash: dockSettings.get_boolean('dock-show-trash'),
       showExternalStorage: dockSettings.get_boolean('dock-show-external-storage'),
+      windowPreviews: dockSettings.get_boolean('dock-window-previews'),
       motionEnabled: dockSettings.get_boolean('dock-motion-enabled'),
       motionProfile: dockSettings.get_string('dock-motion-profile'),
     };
@@ -246,6 +251,7 @@ export class Dock extends Module {
     this._maxIconSize = configuration.maxIconSize;
     this._showTrash = configuration.showTrash;
     this._showExternalStorage = configuration.showExternalStorage;
+    this._windowPreviews = configuration.windowPreviews;
     this._motionEnabled = configuration.motionEnabled;
     this._motionProfile = configuration.motionProfile;
   }
@@ -398,6 +404,7 @@ export class Dock extends Module {
       maxIconSize: this._maxIconSize,
       showTrash: this._showTrash,
       showExternalStorage: this._showExternalStorage,
+      showWindowPreviews: this._windowPreviews,
       position: this._position,
     });
     container.set_child(dash);

--- a/src/dock/dockConfiguration.ts
+++ b/src/dock/dockConfiguration.ts
@@ -9,6 +9,7 @@ export type DockConfiguration = {
   maxIconSize: number;
   showTrash: boolean;
   showExternalStorage: boolean;
+  windowPreviews: boolean;
   motionEnabled: boolean;
   motionProfile: string;
 };
@@ -62,6 +63,7 @@ export function classifyDockConfigurationChange(
     'showOnAllMonitors',
     'showTrash',
     'showExternalStorage',
+    'windowPreviews',
   ];
 
   if (rebuildKeys.some((key) => previous[key] !== next[key])) {

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -16,6 +16,7 @@ import { DashFixedItems } from '~/shared/ui/dashFixedItems.ts';
 import { DashApplicationController } from '~/shared/ui/dashApplications.ts';
 import { DashSpringLoadCoordinator } from '~/shared/ui/dashSpringLoad.ts';
 import { DashVisibilityController } from '~/shared/ui/dashVisibility.ts';
+import { DashWindowPreviewController } from '~/shared/ui/dashWindowPreviews.ts';
 import type { DockPosition } from '~/dock/dockConfiguration.ts';
 import {
   boundsContainPoint,
@@ -40,6 +41,7 @@ interface AuroraDashParams {
   maxIconSize?: number;
   showTrash?: boolean;
   showExternalStorage?: boolean;
+  showWindowPreviews?: boolean;
   position?: DockPosition;
 }
 
@@ -71,6 +73,7 @@ export const AuroraDash = GObject.registerClass(
     declare private _springLoad: DashSpringLoadCoordinator;
     declare private _fixedItems: DashFixedItems;
     declare private _applications: DashApplicationController;
+    declare private _windowPreviews: DashWindowPreviewController | null;
     declare private _unredirectInhibitor: UnredirectInhibitor;
     override _init(params: AuroraDashParams = {}): void {
       super._init();
@@ -81,6 +84,7 @@ export const AuroraDash = GObject.registerClass(
         maxIconSize = 64,
         showTrash = false,
         showExternalStorage = false,
+        showWindowPreviews = false,
         position = 'bottom',
       } = params;
 
@@ -182,6 +186,13 @@ export const AuroraDash = GObject.registerClass(
         getIsolateMonitor: () => this._isolateMonitor,
         getPosition: () => this._position,
       });
+      this._windowPreviews = showWindowPreviews
+        ? new DashWindowPreviewController({
+            position: this._position,
+            isWindowRelevant: (window) => this._applications.isWindowRelevant(window),
+            onOpenStateChanged: () => this._visibility.updateAutoHide(),
+          })
+        : null;
 
       this._fixedItems = new DashFixedItems(this, this, showTrash, showExternalStorage, () => {
         this._queueRedisplay();
@@ -249,6 +260,8 @@ export const AuroraDash = GObject.registerClass(
 
     override destroy(): void {
       this._lifecycle.dispose();
+      if (this._windowPreviews) this._windowPreviews.destroy();
+      this._windowPreviews = null;
       this._visibility.destroy();
       this._springLoad.destroy();
 
@@ -395,10 +408,13 @@ export const AuroraDash = GObject.registerClass(
     }
 
     override hide(animate = true): void {
+      if (this._windowPreviews) this._windowPreviews.close();
       this._visibility.hide(animate);
     }
 
     private _isMenuOpen(): boolean {
+      if (this._windowPreviews && this._windowPreviews.isOpen) return true;
+
       const children = this._applications.getChildren();
 
       for (const child of children) {
@@ -462,6 +478,17 @@ export const AuroraDash = GObject.registerClass(
 
     override _syncLabel(item: any, appIcon: any): void {
       if (!this._dashBox) return;
+
+      if (this._windowPreviews && this._windowPreviews.shouldSuppressTooltip(appIcon)) {
+        const dashAny = this as any;
+        if (dashAny._showLabelTimeoutId > 0) {
+          GLib.source_remove(dashAny._showLabelTimeoutId);
+          dashAny._showLabelTimeoutId = 0;
+        }
+        dashAny._labelShowing = false;
+        if (item) item.hideLabel();
+        return;
+      }
 
       if (item && !item._auroraShowLabelPatched) {
         item._auroraShowLabelPatched = true;
@@ -689,6 +716,9 @@ export const AuroraDash = GObject.registerClass(
       this._syncAppSeparatorGeometry();
       this._syncLabelFlushMode();
       this._applications.installActivationOverrides();
+      if (this._windowPreviews) {
+        this._windowPreviews.syncItems(this._applications.getChildren());
+      }
 
       if (dashAny.iconSize !== oldIconSize) {
         this._iconResizeTimeout.replace(() =>

--- a/src/shared/ui/dashApplications.ts
+++ b/src/shared/ui/dashApplications.ts
@@ -41,7 +41,7 @@ export class DashApplicationController {
         monitor: window.get_monitor(),
         workspace: window.get_workspace() === workspace ? 0 : 1,
         sticky: window.is_on_all_workspaces(),
-        skipTaskbar: false,
+        skipTaskbar: window.is_skip_taskbar(),
       },
       this._options.getMonitorIndex(),
       0,

--- a/src/shared/ui/dashWindowPreviews.ts
+++ b/src/shared/ui/dashWindowPreviews.ts
@@ -1,0 +1,413 @@
+import '@girs/gjs';
+
+import Clutter from '@girs/clutter-18';
+import GLib from '@girs/glib-2.0';
+import GObject from '@girs/gobject-2.0';
+import Graphene from '@girs/graphene-1.0';
+import type Meta from '@girs/meta-18';
+import Pango from '@girs/pango-1.0';
+import Shell from '@girs/shell-18';
+import St from '@girs/st-18';
+import * as BoxPointer from '@girs/gnome-shell/ui/boxpointer';
+import * as Main from '@girs/gnome-shell/ui/main';
+import * as PopupMenu from '@girs/gnome-shell/ui/popupMenu';
+
+import { LifecycleScope, type ManagedSource } from '~/core/lifecycleScope.ts';
+import { createManagedSource } from '~/core/mainLoop.ts';
+import type { DockPosition } from '~/dock/dockConfiguration.ts';
+import { gettext as _ } from '~/shared/i18n.ts';
+
+const SHOW_DELAY = 300;
+const HIDE_DELAY = 150;
+const MAX_PREVIEW_WIDTH = 240;
+const MAX_PREVIEW_HEIGHT = 150;
+const CLOSE_BUTTON_OFFSET = 10;
+const OPEN_SOURCE_STYLE_CLASS = 'aurora-window-preview-open';
+
+const WindowPreviewOverlayLayout = GObject.registerClass(
+  class WindowPreviewOverlayLayout extends Clutter.LayoutManager {
+    override vfunc_get_preferred_width(
+      container: Clutter.Actor,
+      forHeight: number,
+    ): [number, number] {
+      const content = container.first_child;
+      if (!content) return [0, 0];
+      return content.get_preferred_width(forHeight);
+    }
+
+    override vfunc_get_preferred_height(
+      container: Clutter.Actor,
+      forWidth: number,
+    ): [number, number] {
+      const content = container.first_child;
+      if (!content) return [0, 0];
+      return content.get_preferred_height(forWidth);
+    }
+
+    override vfunc_allocate(container: Clutter.Actor, allocation: Clutter.ActorBox): void {
+      const [content, close] = container.get_children();
+      if (content) content.allocate(allocation);
+      if (!close || !close.visible) return;
+
+      const [, closeWidth] = close.get_preferred_width(-1);
+      const [, closeHeight] = close.get_preferred_height(closeWidth);
+      close.allocate(
+        new Clutter.ActorBox({
+          x1: allocation.x2 - closeWidth + CLOSE_BUTTON_OFFSET,
+          y1: allocation.y1 - CLOSE_BUTTON_OFFSET,
+          x2: allocation.x2 + CLOSE_BUTTON_OFFSET,
+          y2: allocation.y1 - CLOSE_BUTTON_OFFSET + closeHeight,
+        }),
+      );
+    }
+  },
+);
+
+type AppIcon = St.Widget & {
+  app?: Shell.App;
+  hover: boolean;
+  _menu?: PopupMenu.PopupMenu | null;
+  _popupMenuSide?: St.Side;
+};
+
+type PreviewSource = {
+  item: St.Widget & { hideLabel?: () => void };
+  appIcon: AppIcon;
+  app: Shell.App;
+};
+
+type DashWindowPreviewOptions = {
+  position: DockPosition;
+  isWindowRelevant: (window: Meta.Window) => boolean;
+  onOpenStateChanged: () => void;
+};
+
+export class DashWindowPreviewController {
+  private _lifecycle = new LifecycleScope();
+  private _showTimer: ManagedSource = createManagedSource(this._lifecycle);
+  private _hideTimer: ManagedSource = createManagedSource(this._lifecycle);
+  private _attachedIcons = new WeakSet<object>();
+  private _pendingSource: PreviewSource | null = null;
+  private _source: PreviewSource | null = null;
+  private _popup: PopupMenu.PopupMenu | null = null;
+
+  constructor(private _options: DashWindowPreviewOptions) {}
+
+  get isOpen(): boolean {
+    if (!this._popup) return false;
+    return this._popup.isOpen;
+  }
+
+  syncItems(items: readonly any[]): void {
+    for (const item of items) {
+      const appIcon = item.child?._delegate as AppIcon | undefined;
+      const app = appIcon?.app;
+      if (!appIcon || !app || this._attachedIcons.has(appIcon)) continue;
+
+      this._attachedIcons.add(appIcon);
+      const source = { item, appIcon, app } satisfies PreviewSource;
+      appIcon.connectObject(
+        'notify::hover',
+        () => this._handleIconHover(source),
+        'clicked',
+        () => this.close(),
+        'menu-state-changed',
+        (_icon: AppIcon, opened: boolean) => {
+          if (opened) this.close();
+        },
+        item,
+      );
+      item.connect('destroy', () => {
+        if (this._pendingSource?.item === item) this._pendingSource = null;
+        if (this._source?.item === item) this.close();
+      });
+    }
+  }
+
+  shouldSuppressTooltip(appIcon: AppIcon | null | undefined): boolean {
+    if (!appIcon || !appIcon.hover || !appIcon.app) return false;
+    return this._getWindows(appIcon.app).length > 0;
+  }
+
+  close(): void {
+    this._showTimer.clear();
+    this._hideTimer.clear();
+    this._pendingSource = null;
+    this._destroyPopup();
+  }
+
+  destroy(): void {
+    this.close();
+    this._lifecycle.dispose();
+  }
+
+  private _handleIconHover(source: PreviewSource): void {
+    if (!source.appIcon.hover) {
+      if (this._pendingSource && this._pendingSource.appIcon === source.appIcon) {
+        this._showTimer.clear();
+        this._pendingSource = null;
+      }
+      if (this._source && this._source.appIcon === source.appIcon) this._scheduleClose();
+      return;
+    }
+
+    if (source.appIcon._menu && source.appIcon._menu.isOpen) return;
+    if (this._getWindows(source.app).length === 0) return;
+
+    if (source.item.hideLabel) source.item.hideLabel();
+    this._hideTimer.clear();
+    if (this._source && this._source.appIcon === source.appIcon && this.isOpen) return;
+
+    const switchImmediately = this.isOpen;
+    if (this._source && this._source.appIcon !== source.appIcon) this._destroyPopup();
+
+    this._pendingSource = source;
+    this._showTimer.replace(() =>
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, switchImmediately ? 0 : SHOW_DELAY, () => {
+        this._showTimer.complete();
+        const pending = this._pendingSource;
+        this._pendingSource = null;
+        if (pending && pending.appIcon.hover) this._open(pending);
+        return GLib.SOURCE_REMOVE;
+      }),
+    );
+  }
+
+  private _open(source: PreviewSource): void {
+    const windows = this._getWindows(source.app);
+    if (windows.length === 0) return;
+    if (source.appIcon._menu && source.appIcon._menu.isOpen) return;
+
+    this._destroyPopup();
+    this._source = source;
+    source.item.add_style_class_name(OPEN_SOURCE_STYLE_CLASS);
+
+    const popupSide = source.appIcon._popupMenuSide
+      ? source.appIcon._popupMenuSide
+      : this._popupSide();
+    const popup = new PopupMenu.PopupMenu(source.appIcon, 0.5, popupSide);
+    popup.actor.add_style_class_name('aurora-window-preview-popup');
+    popup.actor.set_track_hover(true);
+    Main.uiGroup.add_child(popup.actor);
+    popup.actor.hide();
+    this._popup = popup;
+    popup.connect('open-state-changed', (_menu, opened) => {
+      if (!opened && this._popup === popup) this._destroyPopup(true);
+    });
+
+    popup.actor.connectObject(
+      'notify::hover',
+      () => {
+        if (popup.actor.hover) this._hideTimer.clear();
+        else this._scheduleClose();
+      },
+      'key-press-event',
+      (_actor: St.Widget, event: Clutter.Event) => {
+        if (event.get_key_symbol() !== Clutter.KEY_Escape) return Clutter.EVENT_PROPAGATE;
+        this.close();
+        return Clutter.EVENT_STOP;
+      },
+      popup.actor,
+    );
+    source.app.connectObject('windows-changed', () => this._refresh(), popup.actor);
+    global.display.connectObject('notify::focus-window', () => this._refresh(), popup.actor);
+
+    if (!this._populate(popup, windows)) {
+      this._destroyPopup();
+      return;
+    }
+
+    if (source.item.hideLabel) source.item.hideLabel();
+    popup.open(BoxPointer.PopupAnimation.FULL);
+    popup.actor.grab_key_focus();
+    this._options.onOpenStateChanged();
+  }
+
+  private _refresh(): void {
+    if (!this._popup || !this._source) return;
+
+    const windows = this._getWindows(this._source.app);
+    this._popup.removeAll();
+    if (windows.length === 0 || !this._populate(this._popup, windows)) {
+      this.close();
+      return;
+    }
+
+    this._popup.actor.queue_relayout();
+  }
+
+  private _populate(popup: PopupMenu.PopupMenu, windows: Meta.Window[]): boolean {
+    const cards = new St.BoxLayout({
+      style_class: 'aurora-window-preview-list',
+      orientation:
+        this._options.position === 'bottom'
+          ? Clutter.Orientation.HORIZONTAL
+          : Clutter.Orientation.VERTICAL,
+    });
+
+    if (!this._source) return false;
+
+    let cardCount = 0;
+    for (const window of windows) {
+      const card = this._createCard(window, this._source.app.get_name());
+      if (!card) continue;
+      cards.add_child(card);
+      cardCount++;
+    }
+    if (cardCount === 0) return false;
+
+    const monitorIndex = Main.layoutManager.findIndexForActor(this._source.appIcon);
+    const workArea = Main.layoutManager.getWorkAreaForMonitor(Math.max(0, monitorIndex));
+    const workAreaWidth = workArea ? workArea.width : 1200;
+    const workAreaHeight = workArea ? workArea.height : 800;
+    const maxWidth = Math.max(300, Math.floor(workAreaWidth * 0.8));
+    const maxHeight = Math.max(220, Math.floor(workAreaHeight * 0.8));
+    const scroll = new St.ScrollView({
+      style_class: 'aurora-window-preview-scroll',
+      style:
+        this._options.position === 'bottom'
+          ? `max-width: ${maxWidth}px; max-height: 230px;`
+          : `max-width: 280px; max-height: ${maxHeight}px;`,
+      child: cards,
+    });
+    // Both axes stay AUTOMATIC: St compares the child width against the available
+    // height when exactly one axis is AUTOMATIC, which would force a spurious
+    // horizontal scrollbar on the bottom Dock where cards are wider than the
+    // popup is tall.
+    scroll.set_policy(St.PolicyType.AUTOMATIC, St.PolicyType.AUTOMATIC);
+    const host = new PopupMenu.PopupBaseMenuItem({
+      reactive: false,
+      can_focus: false,
+      style_class: 'aurora-window-preview-host',
+    });
+    host.add_child(scroll);
+    popup.addMenuItem(host);
+    return true;
+  }
+
+  private _createCard(window: Meta.Window, fallbackTitle: string): St.BoxLayout | null {
+    if (!window.get_compositor_private()) return null;
+
+    const preview = new Clutter.Actor({
+      pivot_point: new Graphene.Point({ x: 0.5, y: 0.5 }),
+    });
+    const layout = new Shell.WindowPreviewLayout();
+    preview.layout_manager = layout;
+    const rect = window.get_buffer_rect();
+    const width = Math.max(1, rect.width);
+    const height = Math.max(1, rect.height);
+    const scale = Math.min(MAX_PREVIEW_WIDTH / width, MAX_PREVIEW_HEIGHT / height);
+    const previewWidth = Math.max(1, Math.round(width * scale));
+    const previewHeight = Math.max(1, Math.round(height * scale));
+    preview.set_size(previewWidth, previewHeight);
+    const clone = layout.add_window(window);
+    if (!clone) {
+      preview.destroy();
+      return null;
+    }
+    Shell.util_set_hidden_from_pick(clone, true);
+
+    const previewFrame = new St.Bin({
+      style_class: 'aurora-window-preview-thumbnail',
+      child: preview,
+      x_align: Clutter.ActorAlign.CENTER,
+    });
+    const title = new St.Label({
+      style_class: 'aurora-window-preview-title',
+      text: window.title || fallbackTitle,
+      width: previewWidth,
+      x_align: Clutter.ActorAlign.CENTER,
+    });
+    title.clutter_text.single_line_mode = true;
+    title.clutter_text.ellipsize = Pango.EllipsizeMode.END;
+
+    const activationContent = new St.BoxLayout({ orientation: Clutter.Orientation.VERTICAL });
+    activationContent.add_child(previewFrame);
+    activationContent.add_child(title);
+    const activate = new St.Button({
+      style_class: 'aurora-window-preview-activate',
+      child: activationContent,
+      can_focus: true,
+      reactive: true,
+      x_expand: true,
+      y_expand: true,
+      accessible_name: window.title || fallbackTitle,
+    });
+    activate.connect('clicked', () => {
+      this.close();
+      if (window.minimized) window.unminimize();
+      Main.activateWindow(window);
+    });
+    window.connectObject(
+      'notify::title',
+      () => {
+        const windowTitle = window.title || fallbackTitle;
+        title.text = windowTitle;
+        activate.accessible_name = windowTitle;
+      },
+      title,
+    );
+
+    const overlay = new St.Widget({
+      style_class: 'aurora-window-preview-content',
+      layout_manager: new WindowPreviewOverlayLayout(),
+      x_expand: true,
+      y_expand: true,
+    });
+    overlay.add_child(activate);
+
+    if (window.can_close()) {
+      const close = new St.Button({
+        style_class: 'window-close aurora-window-preview-close',
+        icon_name: 'preview-close-symbolic',
+        can_focus: true,
+        reactive: true,
+        accessible_name: _('Close'),
+      });
+      close.connect('clicked', () => {
+        window.delete(global.get_current_time());
+      });
+      overlay.add_child(close);
+    }
+
+    const card = new St.BoxLayout({
+      style_class: 'aurora-window-preview-card',
+      orientation: Clutter.Orientation.VERTICAL,
+      reactive: true,
+      track_hover: true,
+    });
+    card.add_child(overlay);
+    return card;
+  }
+
+  private _getWindows(app: Shell.App): Meta.Window[] {
+    return app.get_windows().filter((window) => this._options.isWindowRelevant(window));
+  }
+
+  private _scheduleClose(): void {
+    this._hideTimer.replace(() =>
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, HIDE_DELAY, () => {
+        this._hideTimer.complete();
+        if (!this._source || !this._popup) return GLib.SOURCE_REMOVE;
+        if (!this._source.appIcon.hover && !this._popup.actor.hover) this.close();
+        return GLib.SOURCE_REMOVE;
+      }),
+    );
+  }
+
+  private _destroyPopup(notifyOpenState = this.isOpen): void {
+    const ownedPopup = this._popup;
+    const ownedSource = this._source;
+    this._popup = null;
+    this._source = null;
+    if (ownedSource) ownedSource.item.remove_style_class_name(OPEN_SOURCE_STYLE_CLASS);
+    if (ownedPopup) ownedPopup.destroy();
+    if (notifyOpenState) this._options.onOpenStateChanged();
+  }
+
+  private _popupSide(): St.Side {
+    if (this._options.position === 'left') return St.Side.RIGHT;
+    if (this._options.position === 'right') return St.Side.LEFT;
+    return St.Side.BOTTOM;
+  }
+}

--- a/src/styles/_dash.scss
+++ b/src/styles/_dash.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 @use 'variables' as vars;
 
 #dash .dash-background {
@@ -191,6 +190,60 @@
   -y-offset: 20px !important;
 }
 
-#dash .dash-item-container.aurora-drag-hover .overview-icon {
+#dash .dash-item-container.aurora-drag-hover .overview-icon,
+#dash .dash-item-container.aurora-window-preview-open .overview-icon {
   background-color: vars.$aurora-dash-hover-bg;
+}
+
+.aurora-window-preview-popup {
+  .popup-menu-content {
+    padding: 8px;
+  }
+
+  .aurora-window-preview-host {
+    padding: 0;
+    background-color: transparent;
+  }
+}
+
+.aurora-window-preview-list {
+  spacing: 8px;
+}
+
+.aurora-window-preview-card {
+  padding: 8px;
+  spacing: 6px;
+  color: vars.$aurora-overview-fg;
+  background-color: vars.$aurora-overview-folder-bg;
+  border-radius: 12px;
+
+  &:hover {
+    background-color: vars.$aurora-overview-hover-bg;
+  }
+}
+
+.aurora-window-preview-content {
+  padding: 0;
+}
+
+.aurora-window-preview-activate {
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+
+  &:focus {
+    box-shadow: inset 0 0 0 2px vars.$aurora-accent-focus-ring;
+    border-radius: 8px;
+  }
+}
+
+.aurora-window-preview-thumbnail {
+  padding: 0;
+}
+
+.aurora-window-preview-title {
+  padding: 6px 4px 2px;
+  color: vars.$aurora-overview-fg;
+  text-align: center;
 }

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -239,6 +239,44 @@ function findDescendant(actor, predicate) {
   return null;
 }
 
+// Window-backed fallback apps (window:N) can be destroyed and recreated with
+// the same id, so icons are matched by app id rather than object identity. An
+// icon still bound to such a dead object reports zero windows and is treated
+// as absent until the Dock redisplays it.
+function findWindowPreviewTarget(dash, app) {
+  const appId = app.get_id();
+  const item = dash._applications
+    .getChildren()
+    .find((candidate) => candidate.child?._delegate?.app?.get_id() === appId);
+  const appIcon = item?.child?._delegate;
+  if (!item || !appIcon) return null;
+  if (appIcon.app.get_windows().length === 0) return null;
+  return { item, appIcon };
+}
+
+// The WindowTracker can re-associate the test window with a different
+// Shell.App once the helper's application id arrives, leaving the previously
+// resolved app without any windows.
+function resolveLivePreviewApp(window, currentApp) {
+  if (currentApp.get_windows().length > 0) return currentApp;
+
+  const reassignedApp = Shell.WindowTracker.get_default().get_window_app(window);
+  return reassignedApp || currentApp;
+}
+
+// A Dock rebuild can leave the icon absent for a few main-loop cycles, so the
+// lookup polls until the item reappears.
+async function waitForWindowPreviewTarget(dash, window, currentApp) {
+  let app = resolveLivePreviewApp(window, currentApp);
+  let target = findWindowPreviewTarget(dash, app);
+  for (let attempt = 0; !target && attempt < 20; attempt++) {
+    await Scripting.sleep(100);
+    app = resolveLivePreviewApp(window, app);
+    target = findWindowPreviewTarget(dash, app);
+  }
+  return { app, target };
+}
+
 async function exerciseWindowPreviews(settings, dock) {
   const previousWindows = new Set(global.get_window_actors().map((actor) => actor.meta_window));
   await Scripting.createTestWindow({ width: 760, height: 480, maximized: false });
@@ -252,8 +290,8 @@ async function exerciseWindowPreviews(settings, dock) {
   if (!window) throw new Error('Could not create a window-preview test window');
 
   try {
-    const app = Shell.WindowTracker.get_default().get_window_app(window);
-    if (!app) throw new Error('Could not resolve the window-preview test application');
+    let previewApp = Shell.WindowTracker.get_default().get_window_app(window);
+    if (!previewApp) throw new Error('Could not resolve the window-preview test application');
 
     settings.set_boolean('dock-window-previews', true);
     await Scripting.waitLeisure();
@@ -268,11 +306,13 @@ async function exerciseWindowPreviews(settings, dock) {
     await Scripting.waitLeisure();
     await Scripting.sleep(300);
 
-    const item = dash._applications
-      .getChildren()
-      .find((candidate) => candidate.child?._delegate?.app === app);
-    const appIcon = item?.child?._delegate;
-    if (!item || !appIcon) throw new Error('Window-preview test application is absent from Dock');
+    // The Dock rebuilds its items when app states settle after the test window
+    // appears, so every interaction re-resolves the current item and icon.
+    let previewState = await waitForWindowPreviewTarget(dash, window, previewApp);
+    previewApp = previewState.app;
+    if (!previewState.target)
+      throw new Error('Window-preview test application is absent from Dock');
+    let { item, appIcon } = previewState.target;
 
     // Drive the real hover contract: a short hover cancels the pending show,
     // a sustained hover suppresses the tooltip and opens the popup after its delay.
@@ -283,14 +323,78 @@ async function exerciseWindowPreviews(settings, dock) {
     if (dash._windowPreviews._popup)
       throw new Error('Window-preview popup opened after its hover was cancelled');
 
+    previewState = await waitForWindowPreviewTarget(dash, window, previewApp);
+    previewApp = previewState.app;
+    if (!previewState.target)
+      throw new Error('Window-preview test application is absent from Dock');
+    ({ item, appIcon } = previewState.target);
     appIcon.set_hover(true);
     if (!dash._windowPreviews.shouldSuppressTooltip(appIcon))
       throw new Error('Window-preview hover did not suppress the Dock tooltip');
-    await Scripting.sleep(500);
 
-    const popup = dash._windowPreviews._popup;
-    if (!popup?.isOpen || !dash._isMenuOpen())
-      throw new Error('Window-preview popup did not open from the icon hover');
+    // Poll instead of a single fixed sleep: GLib dispatches ready sources of
+    // equal priority newest-first, so under CI load a long sleep can resolve
+    // before the show timer even though the timer expired first. A Dock item
+    // rebuild also drops the pending show, in which case the hover is re-armed
+    // against the freshly resolved icon. When no live icon is available, a
+    // forced redisplay reconciles the Dock with the current running apps.
+    let popup = null;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      await Scripting.sleep(100);
+      if (dash._windowPreviews._popup?.isOpen) {
+        popup = dash._windowPreviews._popup;
+        break;
+      }
+      if (dash._windowPreviews._pendingSource) continue;
+
+      previewApp = resolveLivePreviewApp(window, previewApp);
+      const target = findWindowPreviewTarget(dash, previewApp);
+      if (!target) {
+        dash.refresh();
+        continue;
+      }
+
+      ({ item, appIcon } = target);
+      appIcon.set_hover(false);
+      appIcon.set_hover(true);
+    }
+    if (!popup || !dash._isMenuOpen()) {
+      const controller = dash._windowPreviews;
+      const fresh = findWindowPreviewTarget(dash, previewApp);
+      const windows = previewApp.get_windows();
+      const windowAlive = global.get_window_actors().some((actor) => actor.meta_window === window);
+      const currentApp = windowAlive
+        ? Shell.WindowTracker.get_default().get_window_app(window)
+        : null;
+      const iconApp = fresh?.appIcon.app;
+      const diagnostics = [
+        `pending=${Boolean(controller._pendingSource)}`,
+        `showTimerActive=${controller._showTimer?.active}`,
+        `hover=${fresh ? fresh.appIcon.hover : 'n/a'}`,
+        `appWindows=${windows.length}`,
+        `relevantWindows=${windows.filter((w) => controller._options.isWindowRelevant(w)).length}`,
+        `skipTaskbar=${windows.map((w) => w.is_skip_taskbar()).join(',')}`,
+        `menuOpen=${Boolean(fresh?.appIcon._menu?.isOpen)}`,
+        `windowAlive=${windowAlive}`,
+        `compositorPrivate=${windowAlive ? Boolean(window.get_compositor_private()) : 'n/a'}`,
+        `sameApp=${currentApp === previewApp}`,
+        `iconSameAsPreview=${iconApp ? iconApp === previewApp : 'n/a'}`,
+        `iconAppWindows=${iconApp ? iconApp.get_windows().length : 'n/a'}`,
+        `iconApp=${iconApp?.get_id()}`,
+        `windowApp=${currentApp?.get_id()}`,
+        `testApp=${previewApp.get_id()}`,
+        `sameDash=${dock.bindings[0]?.dash === dash}`,
+        `dashBoxMissing=${!dash._dashBox}`,
+        `dockChildren=${dash._applications.getChildren().length}`,
+        `childApps=${dash._applications
+          .getChildren()
+          .map((child) => child.child?._delegate?.app?.get_id())
+          .join('|')}`,
+      ];
+      throw new Error(
+        `Window-preview popup did not open from the icon hover [${diagnostics.join(' ')}]`,
+      );
+    }
     if (global.stage.get_key_focus() !== popup.actor)
       throw new Error('Window-preview popup did not take the keyboard focus');
     popup.actor.set_hover(true);
@@ -925,11 +1029,19 @@ export async function run() {
   dash.show(true);
   dash.show(true);
   dash.show(true);
-  await Scripting.sleep(300);
+
+  // Poll for the settled pose instead of a fixed sleep: the 200ms show
+  // animation only starts on the next frame, so under CI load a single
+  // 300ms wait can sample the dock mid-animation.
+  let settled = false;
+  for (let attempt = 0; attempt < 20 && !settled; attempt++) {
+    await Scripting.sleep(100);
+    settled = dash.visible && dash.opacity === 255 && dash.translation_y === 0;
+  }
   dash._visibility._applyHiddenState = originalApplyHiddenState;
   if (hiddenPoseCalls !== 1)
     throw new Error(`Repeated show requests restarted the animation ${hiddenPoseCalls} times`);
-  if (!dash.visible || dash.opacity !== 255 || dash.translation_y !== 0)
+  if (!settled)
     throw new Error('Dock did not settle in its fully shown state after repeated show requests');
 
   Scripting.scriptEvent('repeatedShowStable');

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -5,6 +5,7 @@ import * as Scripting from 'resource:///org/gnome/shell/ui/scripting.js';
 import { Dash as ShellDash } from 'resource:///org/gnome/shell/ui/dash.js';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
+import Pango from 'gi://Pango';
 import Shell from 'gi://Shell';
 import St from 'gi://St';
 import {
@@ -226,6 +227,181 @@ function edgeIsReachable(monitors, index, position) {
   });
 }
 
+function findDescendant(actor, predicate) {
+  if (predicate(actor)) return actor;
+  if (!actor?.get_children) return null;
+
+  for (const child of actor.get_children()) {
+    const match = findDescendant(child, predicate);
+    if (match) return match;
+  }
+
+  return null;
+}
+
+async function exerciseWindowPreviews(settings, dock) {
+  const previousWindows = new Set(global.get_window_actors().map((actor) => actor.meta_window));
+  await Scripting.createTestWindow({ width: 760, height: 480, maximized: false });
+  await Scripting.waitTestWindows();
+  await Scripting.sleep(300);
+
+  const window = global
+    .get_window_actors()
+    .map((actor) => actor.meta_window)
+    .find((candidate) => !previousWindows.has(candidate));
+  if (!window) throw new Error('Could not create a window-preview test window');
+
+  try {
+    const app = Shell.WindowTracker.get_default().get_window_app(window);
+    if (!app) throw new Error('Could not resolve the window-preview test application');
+
+    settings.set_boolean('dock-window-previews', true);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(500);
+
+    const dash = dock?.bindings?.[0]?.dash;
+    if (!dash?._windowPreviews)
+      throw new Error('Window-preview controller was not created when enabled');
+
+    dash.show(false);
+    dash.refresh();
+    await Scripting.waitLeisure();
+    await Scripting.sleep(300);
+
+    const item = dash._applications
+      .getChildren()
+      .find((candidate) => candidate.child?._delegate?.app === app);
+    const appIcon = item?.child?._delegate;
+    if (!item || !appIcon) throw new Error('Window-preview test application is absent from Dock');
+
+    // Drive the real hover contract: a short hover cancels the pending show,
+    // a sustained hover suppresses the tooltip and opens the popup after its delay.
+    appIcon.set_hover(true);
+    await Scripting.sleep(150);
+    appIcon.set_hover(false);
+    await Scripting.sleep(400);
+    if (dash._windowPreviews._popup)
+      throw new Error('Window-preview popup opened after its hover was cancelled');
+
+    appIcon.set_hover(true);
+    if (!dash._windowPreviews.shouldSuppressTooltip(appIcon))
+      throw new Error('Window-preview hover did not suppress the Dock tooltip');
+    await Scripting.sleep(500);
+
+    const popup = dash._windowPreviews._popup;
+    if (!popup?.isOpen || !dash._isMenuOpen())
+      throw new Error('Window-preview popup did not open from the icon hover');
+    if (global.stage.get_key_focus() !== popup.actor)
+      throw new Error('Window-preview popup did not take the keyboard focus');
+    popup.actor.set_hover(true);
+    if (!item.has_style_class_name('aurora-window-preview-open'))
+      throw new Error('Window-preview popup did not keep its Dock item highlighted');
+
+    const preview = findDescendant(
+      popup.actor,
+      (actor) => actor.layout_manager instanceof Shell.WindowPreviewLayout,
+    );
+    if (!preview) throw new Error('Window-preview popup does not contain a live thumbnail');
+
+    const thumbnail = findDescendant(
+      popup.actor,
+      (actor) =>
+        actor.has_style_class_name && actor.has_style_class_name('aurora-window-preview-thumbnail'),
+    );
+    if (!thumbnail) throw new Error('Window-preview popup does not contain its thumbnail frame');
+    const title = findDescendant(
+      popup.actor,
+      (actor) =>
+        actor.has_style_class_name && actor.has_style_class_name('aurora-window-preview-title'),
+    );
+    if (!title || title.clutter_text.line_alignment !== Pango.Alignment.CENTER)
+      throw new Error('Window-preview title is not centered');
+    const [previewWidth, previewHeight] = preview.get_transformed_size();
+    const [thumbnailWidth, thumbnailHeight] = thumbnail.get_transformed_size();
+    if (
+      Math.abs(previewWidth - thumbnailWidth) > 2 ||
+      Math.abs(previewHeight - thumbnailHeight) > 2
+    ) {
+      throw new Error('Window-preview thumbnail does not follow the window aspect ratio');
+    }
+
+    const scroll = findDescendant(popup.actor, (actor) => actor instanceof St.ScrollView);
+    if (!scroll) throw new Error('Window-preview popup does not contain its viewport');
+    if (
+      scroll.hscrollbar_policy !== St.PolicyType.AUTOMATIC ||
+      scroll.vscrollbar_policy !== St.PolicyType.AUTOMATIC
+    ) {
+      throw new Error('Window-preview popup cannot scroll its overflow');
+    }
+    if (scroll.hscrollbar_visible || scroll.vscrollbar_visible)
+      throw new Error('Window-preview popup exposed a scrollbar for content that fits');
+
+    const minimize = findDescendant(
+      popup.actor,
+      (actor) => actor.child?.icon_name === 'window-minimize-symbolic',
+    );
+    if (minimize) throw new Error('Window-preview popup still exposes minimize action');
+
+    const card = findDescendant(
+      popup.actor,
+      (actor) =>
+        actor.has_style_class_name && actor.has_style_class_name('aurora-window-preview-card'),
+    );
+    if (!card || !card.reactive || !card.track_hover)
+      throw new Error('Window-preview card does not track pointer hover');
+    if (card.has_style_class_name('focused'))
+      throw new Error('Window-preview card still exposes a focused-window border');
+    card.set_hover(true);
+    if (!card.has_style_pseudo_class('hover'))
+      throw new Error('Window-preview card did not enter its hover state');
+    card.set_hover(false);
+
+    const close = findDescendant(
+      popup.actor,
+      (actor) =>
+        actor.has_style_class_name && actor.has_style_class_name('aurora-window-preview-close'),
+    );
+    if (!close || !close.has_style_class_name('window-close'))
+      throw new Error('Window-preview popup does not expose the native circular close action');
+
+    const overlay = close.get_parent();
+    const [overlayX, overlayY] = overlay.get_transformed_position();
+    const [overlayWidth] = overlay.get_transformed_size();
+    const [closeX, closeY] = close.get_transformed_position();
+    const [closeWidth] = close.get_transformed_size();
+    const closeRight = closeX + closeWidth;
+    const overlayRight = overlayX + overlayWidth;
+    const horizontalOffset = closeRight - overlayRight;
+    const verticalOffset = overlayY - closeY;
+    if (
+      horizontalOffset < 6 ||
+      verticalOffset < 6 ||
+      Math.abs(horizontalOffset - verticalOffset) > 2
+    ) {
+      throw new Error('Window-preview close action is not consistently offset past the corner');
+    }
+
+    close.emit('clicked', Clutter.BUTTON_PRIMARY);
+    await Scripting.sleep(500);
+    if (item.has_style_class_name('aurora-window-preview-open'))
+      throw new Error('Window-preview Dock highlight survived popup closure');
+    if (global.get_window_actors().some((actor) => actor.meta_window === window))
+      throw new Error('Window-preview close action did not close the window');
+
+    dash._windowPreviews.close();
+    if (dash._windowPreviews._popup)
+      throw new Error('Window-preview actors were retained after popup close');
+
+    appIcon.set_hover(false);
+  } finally {
+    if (global.get_window_actors().some((actor) => actor.meta_window === window))
+      window.delete(global.get_current_time());
+    settings.set_boolean('dock-window-previews', false);
+    await Scripting.waitLeisure();
+    await Scripting.sleep(300);
+  }
+}
+
 async function exerciseDockPositions(settings, dock) {
   settings.set_boolean('dock-show-on-all-monitors', false);
   settings.set_boolean('dock-always-show', false);
@@ -444,6 +620,10 @@ export function init() {
     'Dash content destruction cancels callbacks before actors are disposed',
   );
   Scripting.defineScriptEvent(
+    'windowPreviewsValid',
+    'Window previews create live thumbnails and an overlaid close action only while open',
+  );
+  Scripting.defineScriptEvent(
     'externalStorageDisabled',
     'External storage dock icons are absent when disabled',
   );
@@ -480,6 +660,7 @@ export async function run() {
   const originalIconSize = settings.get_user_value('dock-icon-size');
   const originalMotionEnabled = settings.get_boolean('dock-motion-enabled');
   const originalMotionProfile = settings.get_string('dock-motion-profile');
+  const originalWindowPreviews = settings.get_boolean('dock-window-previews');
   settings.set_boolean('dock-show-trash', true);
   settings.set_boolean('dock-show-external-storage', false);
   settings.set_boolean('dock-always-show', false);
@@ -489,6 +670,7 @@ export async function run() {
   settings.set_int('dock-icon-size', 64);
   settings.set_boolean('dock-motion-enabled', true);
   settings.set_string('dock-motion-profile', 'balanced');
+  settings.set_boolean('dock-window-previews', false);
 
   await Scripting.waitLeisure();
   await Scripting.sleep(500);
@@ -509,6 +691,8 @@ export async function run() {
   const dock = getAuroraModule('dock');
 
   await exerciseMonitorScope(settings, dock);
+  await exerciseWindowPreviews(settings, dock);
+  Scripting.scriptEvent('windowPreviewsValid');
 
   const dash = dock?.bindings?.[0]?.dash;
   const showAppsIcon = dash?._showAppsIcon;
@@ -1146,6 +1330,7 @@ export async function run() {
   }
   settings.set_boolean('dock-motion-enabled', originalMotionEnabled);
   settings.set_string('dock-motion-profile', originalMotionProfile);
+  settings.set_boolean('dock-window-previews', originalWindowPreviews);
   settings.set_boolean('module-dock', originalValue);
   await Scripting.waitLeisure();
   await Scripting.sleep(300);
@@ -1176,6 +1361,7 @@ let _primaryMonitorOnly = false;
 let _allMonitorsEnabled = false;
 let _alwaysAutoHideIndependent = false;
 let _dashContentDisposalSafe = false;
+let _windowPreviewsValid = false;
 
 export function script_dockPresent() {
   _dockPresent = true;
@@ -1277,6 +1463,10 @@ export function script_dashContentDisposalSafe() {
   _dashContentDisposalSafe = true;
 }
 
+export function script_windowPreviewsValid() {
+  _windowPreviewsValid = true;
+}
+
 export function finish() {
   if (!_dockPresent)
     throw new Error('Dock actor was not found in the stage after extension enable');
@@ -1317,5 +1507,7 @@ export function finish() {
     throw new Error('Dock always auto-hide behavior was not verified');
   if (!_dashContentDisposalSafe)
     throw new Error('Dash content disposal did not cancel pending actor access');
+  if (!_windowPreviewsValid)
+    throw new Error('Window-preview thumbnail and close action were not verified');
   if (!_dockRemoved) throw new Error('Dock actor was not removed after module was disabled');
 }

--- a/tests/shell/dock/scenarios/monitors.js
+++ b/tests/shell/dock/scenarios/monitors.js
@@ -18,6 +18,7 @@ export async function exerciseMonitorScope(settings, dock) {
     get_monitor: () => monitorIndex,
     is_on_all_workspaces: () => false,
     get_workspace: () => global.workspace_manager.get_active_workspace(),
+    is_skip_taskbar: () => false,
   };
   if (!dock.bindings[0].dash._applications.isWindowRelevant(externalWindow))
     throw new Error('Primary-only Dock excluded an external-monitor app');

--- a/tests/unit/dock/dockConfiguration.test.ts
+++ b/tests/unit/dock/dockConfiguration.test.ts
@@ -15,6 +15,7 @@ const base: DockConfiguration = {
   maxIconSize: 64,
   showTrash: true,
   showExternalStorage: true,
+  windowPreviews: false,
   motionEnabled: true,
   motionProfile: 'subtle',
 };
@@ -36,6 +37,7 @@ test('dock configuration controller publishes typed snapshots and transition sco
 test('dock configuration distinguishes rebuild, icon-size and motion updates', () => {
   assert.equal(classifyDockConfigurationChange(base, { ...base, position: 'left' }), 'rebuild');
   assert.equal(classifyDockConfigurationChange(base, { ...base, showTrash: false }), 'rebuild');
+  assert.equal(classifyDockConfigurationChange(base, { ...base, windowPreviews: true }), 'rebuild');
   assert.equal(classifyDockConfigurationChange(base, { ...base, maxIconSize: 32 }), 'icon-size');
   assert.equal(classifyDockConfigurationChange(base, { ...base, motionEnabled: false }), 'motion');
   assert.equal(classifyDockConfigurationChange(base, { ...base }), 'none');

--- a/tests/unit/project/schema.test.ts
+++ b/tests/unit/project/schema.test.ts
@@ -242,6 +242,10 @@ test('schema: Dock uses always auto-hide by default', () => {
   assert.equal(schemaDefault('dock-intellihide'), 'false');
 });
 
+test('schema: Dock window previews are opt-in by default', () => {
+  assert.equal(schemaDefault('dock-window-previews'), 'false');
+});
+
 test('schema: Volume Mixer button is contextual by default', () => {
   assert.equal(schemaDefault('volume-mixer-always-show'), 'false');
 });


### PR DESCRIPTION
Show a hover popup next to Dock icons listing every relevant window of the application with a live thumbnail (Shell.WindowPreviewLayout), the centered window title, an activation action, and the native circular close action. The popup opens after a 300ms hover delay, cancels when the pointer leaves before the delay elapses, switches immediately when moving between icons, suppresses the Dock tooltip while hovered, and keeps the source item highlighted until it closes.

- Gate the feature behind the new dock-window-previews setting
- Exclude skip-taskbar windows so auxiliary dialogs never appear with a close action; running dots and activation cycling share the same relevance filter
- Wrap the card list in a ScrollView capped at 80% of the work area with AUTOMATIC policy on both axes so apps with many windows stay reachable (St miscompares the child width against the available height when only one axis is AUTOMATIC, which would force a spurious horizontal scrollbar on the bottom Dock)
- Grab keyboard focus on open so Escape closes the popup and the card buttons are keyboard-operable, and render the theme focus ring on the activation button instead of suppressing it
- Keep the accessible name of the activation button in sync with notify::title so screen readers announce the current window title
- Hold Dock visibility while the popup is open and destroy popup, clones, timers, and signal connections on close

Cover the feature through the real hover contract in the Dock Shell test (cancel-on-leave, tooltip suppression, open delay, keyboard focus, thumbnail aspect ratio, scroll policies, close action) and extend the monitor-scope mock window with is_skip_taskbar().

Refs #64 