### PR TITLE
ci: fix bump branch variable in pull request step

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -65,7 +65,6 @@ jobs:
           set -euo pipefail
 
           BUMP_BRANCH="bot/bump-version-${BRANCH//\//-}-${VERSION}"
-          echo "bump_branch=$BUMP_BRANCH" >> "$GITHUB_ENV"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -82,6 +81,8 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           set -euo pipefail
+
+          BUMP_BRANCH="bot/bump-version-${BRANCH//\//-}-${VERSION}"
 
           PR_URL="$(gh pr list --head "$BUMP_BRANCH" --state open --json url --jq '.[0].url // empty')"
           if [[ -n "$PR_URL" ]]; then


### PR DESCRIPTION
The `Open pull request` step of the Bump version workflow read `$BUMP_BRANCH`, but the previous step exported it to `$GITHUB_ENV` as lowercase `bump_branch`, so the run failed with `BUMP_BRANCH: unbound variable`. Each step now builds the branch name locally from the workflow inputs instead of sharing state through `$GITHUB_ENV`.