### PR TITLE
fix(dock): overlay scrollbars in window previews to drop right gutter

### DIFF
--- a/src/shared/ui/dashWindowPreviews.ts
+++ b/src/shared/ui/dashWindowPreviews.ts
@@ -269,11 +269,14 @@ export class DashWindowPreviewController {
           ? `max-width: ${maxWidth}px; max-height: 230px;`
           : `max-width: 280px; max-height: ${maxHeight}px;`,
       child: cards,
+      overlay_scrollbars: true,
     });
     // Both axes stay AUTOMATIC: St compares the child width against the available
     // height when exactly one axis is AUTOMATIC, which would force a spurious
     // horizontal scrollbar on the bottom Dock where cards are wider than the
-    // popup is tall.
+    // popup is tall. Overlay scrollbars keep St from permanently reserving the
+    // vertical scrollbar width in the preferred size, which otherwise shows up
+    // as an empty gutter on the right side of the popup.
     scroll.set_policy(St.PolicyType.AUTOMATIC, St.PolicyType.AUTOMATIC);
     const host = new PopupMenu.PopupBaseMenuItem({
       reactive: false,


### PR DESCRIPTION
The window preview popup always showed an empty gutter on the right side, the exact width of a scrollbar.

Root cause in St: with `ST_POLICY_AUTOMATIC` and overlay scrollbars disabled, `st_scroll_view_get_preferred_width()` unconditionally reserves the vertical scrollbar width in the preferred size, because whether a vertical scrollbar is actually needed is only known at allocate time. The preview cards always fit the max height, so the scrollbar never appears, but its reserved gutter stays.

Setting `overlay_scrollbars: true` on the previews `St.ScrollView` removes the reservation; when scrolling is genuinely needed the bar overlays the content instead of displacing it. Both axes stay `AUTOMATIC`: with vertical `NEVER` and horizontal `AUTOMATIC`, St's allocate path compares the child width against the available height, which forces a spurious horizontal scrollbar on the bottom dock (the case the existing comment already documents).

Validated with tsc/eslint/prettier/stylelint, Shell dock tests in the toolbox (1 passed, 0 failed) and shexli (0 errors; only the 3 documented false positives from docs/extension-review.md).
