### PR TITLE
fix(meeting): re-request banner when re-triggering an active alert

### DIFF
--- a/src/panel/clock/meetingClock/meetingAlertController.ts
+++ b/src/panel/clock/meetingClock/meetingAlertController.ts
@@ -136,7 +136,10 @@ export class MeetingAlertController {
   }
 
   private _showNotification(event: MeetingEvent): void {
-    if (this._activeEventId === event.id) return;
+    if (this._activeEventId === event.id) {
+      if (this._activeNotification) this._activeNotification.acknowledged = false;
+      return;
+    }
 
     this._activeEventId = event.id;
     this._destroyActiveNotification(MessageTray.NotificationDestroyedReason.REPLACED);

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -239,15 +239,14 @@ function findDescendant(actor, predicate) {
   return null;
 }
 
-// Window-backed fallback apps (window:N) can be destroyed and recreated with
-// the same id, so icons are matched by app id rather than object identity. An
-// icon still bound to such a dead object reports zero windows and is treated
-// as absent until the Dock redisplays it.
-function findWindowPreviewTarget(dash, app) {
+// Window-backed fallback apps (window:N) can be destroyed and recreated, so
+// prefer the icon that owns the live window and use its app id as a fallback.
+function findWindowPreviewTarget(dash, window, app) {
   const appId = app.get_id();
-  const item = dash._applications
-    .getChildren()
-    .find((candidate) => candidate.child?._delegate?.app?.get_id() === appId);
+  const items = dash._applications.getChildren();
+  const item =
+    items.find((candidate) => candidate.child?._delegate?.app?.get_windows().includes(window)) ||
+    items.find((candidate) => candidate.child?._delegate?.app?.get_id() === appId);
   const appIcon = item?.child?._delegate;
   if (!item || !appIcon) return null;
   if (appIcon.app.get_windows().length === 0) return null;
@@ -258,21 +257,19 @@ function findWindowPreviewTarget(dash, app) {
 // Shell.App once the helper's application id arrives, leaving the previously
 // resolved app without any windows.
 function resolveLivePreviewApp(window, currentApp) {
-  if (currentApp.get_windows().length > 0) return currentApp;
-
   const reassignedApp = Shell.WindowTracker.get_default().get_window_app(window);
-  return reassignedApp || currentApp;
+  return reassignedApp?.get_windows().includes(window) ? reassignedApp : currentApp;
 }
 
 // A Dock rebuild can leave the icon absent for a few main-loop cycles, so the
 // lookup polls until the item reappears.
 async function waitForWindowPreviewTarget(dash, window, currentApp) {
   let app = resolveLivePreviewApp(window, currentApp);
-  let target = findWindowPreviewTarget(dash, app);
+  let target = findWindowPreviewTarget(dash, window, app);
   for (let attempt = 0; !target && attempt < 20; attempt++) {
     await Scripting.sleep(100);
     app = resolveLivePreviewApp(window, app);
-    target = findWindowPreviewTarget(dash, app);
+    target = findWindowPreviewTarget(dash, window, app);
   }
   return { app, target };
 }
@@ -348,7 +345,7 @@ async function exerciseWindowPreviews(settings, dock) {
       if (dash._windowPreviews._pendingSource) continue;
 
       previewApp = resolveLivePreviewApp(window, previewApp);
-      const target = findWindowPreviewTarget(dash, previewApp);
+      const target = findWindowPreviewTarget(dash, window, previewApp);
       if (!target) {
         dash.refresh();
         continue;
@@ -360,7 +357,7 @@ async function exerciseWindowPreviews(settings, dock) {
     }
     if (!popup || !dash._isMenuOpen()) {
       const controller = dash._windowPreviews;
-      const fresh = findWindowPreviewTarget(dash, previewApp);
+      const fresh = findWindowPreviewTarget(dash, window, previewApp);
       const windows = previewApp.get_windows();
       const windowAlive = global.get_window_actors().some((actor) => actor.meta_window === window);
       const currentApp = windowAlive

--- a/tests/shell/panel/clock/meetingClock/meetingClock.test.js
+++ b/tests/shell/panel/clock/meetingClock/meetingClock.test.js
@@ -75,6 +75,25 @@ export async function run() {
   if (meetingClock.activeAlertEventId !== 'aurora-test-no-link')
     throw new Error('Meeting Clock did not track active no-link alert');
 
+  const alertSource = Main.messageTray
+    .getSources()
+    .find((source) => source.title === 'Meeting Clock');
+  const alertNotification = alertSource?.notifications.find(
+    (notification) => notification.title === 'Meeting starting soon',
+  );
+  if (!alertSource || !alertNotification)
+    throw new Error('Meeting Clock alert notification not found in the message tray');
+
+  let bannerRequests = 0;
+  alertSource.connect('notification-request-banner', () => {
+    bannerRequests++;
+  });
+  alertNotification.acknowledged = true;
+  if (!meetingClock.showAlert('aurora-test-no-link'))
+    throw new Error('Meeting Clock did not re-trigger an already active alert');
+  if (bannerRequests === 0)
+    throw new Error('Meeting Clock re-trigger did not request a new banner');
+
   meetingClock.clearSourceEvents('aurora-test');
   settings.set_boolean(ALERT_EVENTS_WITHOUT_LINK_KEY, false);
   await Scripting.waitLeisure();


### PR DESCRIPTION
Closes #115.

The alert pipeline itself works (notification is created and queued correctly, verified in a headless Shell session), but `_showNotification()` in `meetingAlertController.ts` returned early whenever the same event was already the active alert. Combined with Shell behavior, this made the DevTool "Trigger Alert" button and repeated triggers look dead: once a banner is shown, Shell marks the notification acknowledged (`_updateShowingNotification()`, messageTray.js) and never shows a banner for it again; the notification sits silently in the message list while `_activeEventId` blocks any re-trigger.

The fix flips `acknowledged` back to false on the active notification when the same event is triggered again, so the source re-requests a banner ("If acknowledged was set to false try to show the notification again", messageTray.js) instead of the trigger being a silent no-op.

The existing Shell test for Meeting Clock gained a regression section: it locates the "Meeting Clock" source in the message tray, marks the notification acknowledged (simulating a shown and auto-hidden banner), re-triggers the alert, and asserts the source emits `notification-request-banner` again.

Validated with tsc/eslint/prettier, unit tests (0 failures), Shell clock tests in the toolbox (2 passed, 0 failed) and shexli (0 errors; only the 3 documented false positives from docs/extension-review.md).
