### PR TITLE
fix(dock): sync hover before autohide handoff

### DIFF
--- a/src/dock/dock.ts
+++ b/src/dock/dock.ts
@@ -715,6 +715,7 @@ export class Dock extends Module {
   }
 
   private _handOffBlockedDockToAutoHide(binding: ManagedDockBinding): void {
+    binding.dash.syncHover();
     binding.dash.blockAutoHide(false);
     binding.dash.ensureAutoHide();
     this._enableHotAreaWhenDockHidden(binding);

--- a/src/shared/ui/dash.ts
+++ b/src/shared/ui/dash.ts
@@ -250,6 +250,10 @@ export const AuroraDash = GObject.registerClass(
       return this._visibility.hovered;
     }
 
+    syncHover(): void {
+      this._dashContainer.sync_hover();
+    }
+
     containsStagePoint(x: number, y: number): boolean {
       return (
         boundsContainPoint(this._getActorStageBounds(this._container), x, y) ||

--- a/tests/shell/dock/dock.test.js
+++ b/tests/shell/dock/dock.test.js
@@ -1406,9 +1406,11 @@ export async function run() {
   // Reasserting BLOCKED reproduces the maximized-window switch where stage
   // motion missed the pointer leaving the Dock.
   const originalBlockedDashContainerHasHover = dash._visibility._hovered;
+  const originalSyncHover = dash._dashContainer.sync_hover;
   try {
     binding.intellihide._status = 1; // BLOCKED
-    dash._visibility._hovered = true; // pointer over the dock
+    dash._visibility._hovered = false; // stale after a pointer grab
+    dash._dashContainer.sync_hover = () => dash._visibility.setHovered(true);
     binding.hotAreaActive = true;
     binding.dash.blockAutoHide(true);
     dash.show(false);
@@ -1441,6 +1443,7 @@ export async function run() {
       description: 'hot area to rearm after the BLOCKED Dock retracts',
     });
   } finally {
+    dash._dashContainer.sync_hover = originalSyncHover;
     dash._visibility._hovered = originalBlockedDashContainerHasHover;
   }
   if (dash.visible)


### PR DESCRIPTION
This fixes an intellihide race where the Dock could be revealed from the hot area and then hide again because its hover state was stale after a pointer grab or actor reparenting. The Dock now asks St to synchronize the current hover state before handing visibility back to native autohide, so it stays open while the pointer is over it and retracts normally after the pointer leaves. A Shell regression test covers the stale-hover handoff.